### PR TITLE
Lambda http

### DIFF
--- a/packages/aws-utils/bin/createCognitoUser.js
+++ b/packages/aws-utils/bin/createCognitoUser.js
@@ -1,0 +1,100 @@
+#! /usr/bin/env node
+
+// XXX: Hack to ensure we get the test config.
+process.env.NODE_ENV = 'test';
+// needed for amazon-cognito-identity-js
+global.fetch = require('node-fetch');
+
+const uuid = require('uuid/v4');
+const aws = require('aws-sdk');
+const createConfig = require('@conduitvc/config');
+const AmazonCognitoIdentity = require('amazon-cognito-identity-js');
+
+const config = createConfig(module.parent);
+const userPool = new AmazonCognitoIdentity.CognitoUserPool({
+  UserPoolId: config.userPool.id,
+  ClientId: config.userPool.clientId,
+  region: config.cognito.region,
+});
+
+const createUser = async (cognito, { userPoolId, username, password }) => {
+  const tempPassword = uuid();
+  await cognito
+    .adminCreateUser({
+      UserPoolId: userPoolId,
+      Username: username,
+      MessageAction: 'SUPPRESS',
+      TemporaryPassword: tempPassword,
+      UserAttributes: [
+        { Name: 'email_verified', Value: 'True' },
+        { Name: 'email', Value: 'user@example.com' },
+      ],
+    })
+    .promise();
+
+  const authDetails = new AmazonCognitoIdentity.AuthenticationDetails({
+    Username: username,
+    Password: tempPassword,
+  });
+  const user = new AmazonCognitoIdentity.CognitoUser({
+    Username: username,
+    Pool: userPool,
+  });
+  user.setAuthenticationFlowType('USER_SRP_AUTH');
+
+  await new Promise((accept, reject) => {
+    user.authenticateUser(authDetails, {
+      onSuccess: () => {
+        accept(user);
+      },
+      onFailure: (err) => {
+        reject(err);
+      },
+      newPasswordRequired: () => {
+        accept(user);
+      },
+    });
+  });
+
+  await new Promise((accept, reject) => {
+    user.completeNewPasswordChallenge(
+      password,
+      {},
+      {
+        onSuccess: accept,
+        onFailure: reject,
+      },
+    );
+  });
+
+  return user;
+};
+
+async function main() {
+  const username = uuid();
+  const password = uuid();
+  const cognito = new aws.CognitoIdentityServiceProvider(config.cognito);
+  const user = await createUser(cognito, {
+    userPoolId: config.userPool.id,
+    username,
+    password,
+  });
+
+  const idKey = user
+    .getSignInUserSession()
+    .getIdToken()
+    .getJwtToken();
+
+  console.log('Created Cognito user for testing:');
+  console.log();
+  console.log('  Username: ', username);
+  console.log('  Password: ', password);
+  console.log('  JWT ID Token:');
+  console.log(idKey);
+  console.log();
+}
+
+main().catch((err) => {
+  console.error('Something went wrong', err.stack);
+  process.exit(1);
+});

--- a/packages/aws-utils/findServerless.js
+++ b/packages/aws-utils/findServerless.js
@@ -1,0 +1,28 @@
+const GlobalCache = {};
+const yaml = require('js-yaml');
+const path = require('path');
+const pkgUp = require('pkg-up');
+const fs = require('fs');
+
+const findServerlessPath = ({ parent: { filename } } = module) =>
+  path.dirname(pkgUp.sync(filename));
+
+const findServerless = (mod = module) => {
+  const serverlessPath = path.join(findServerlessPath(mod), 'serverless.yml');
+  if (GlobalCache[serverlessPath]) {
+    return GlobalCache[serverlessPath];
+  }
+
+  if (!fs.existsSync(serverlessPath)) {
+    throw new Error(`Expected serverless file at location: ${serverlessPath}`);
+  }
+
+  const parsed = yaml.safeLoad(fs.readFileSync(serverlessPath, 'utf8'));
+  // eslint-disable-next-lin
+  return (GlobalCache[serverlessPath] = parsed);
+};
+
+module.exports = {
+  findServerlessPath,
+  findServerless,
+};

--- a/packages/aws-utils/lambdaHttp.js
+++ b/packages/aws-utils/lambdaHttp.js
@@ -1,0 +1,184 @@
+/**
+ * This is intended to be a test helper for jest to run lambda functions
+ * as a full http server.
+ */
+const e2p = require('event-to-promise');
+const http = require('http');
+const util = require('util');
+const { findServerless, findServerlessPath } = require('./findServerless');
+const path = require('path');
+
+function drainStream(stream) {
+  return new Promise((accept, reject) => {
+    const buffers = [];
+    stream.on('data', data => buffers.push(data));
+    stream.once('end', () => accept(Buffer.concat(buffers).toString()));
+    stream.once('error', reject);
+  });
+}
+
+async function convertRequestToLambdaRequest(req) {
+  const body = await drainStream(req);
+  return {
+    resource: req.url,
+    path: req.url,
+    httpMethod: req.method,
+    headers: {
+      Accept: '*/*',
+      'Accept-Encoding': 'gzip, deflate, br',
+      'Accept-Language': 'en-US,en;q=0.9',
+      Authorization:
+        'eyJraWQiOiI2SnRBWkxOdFIrSENMK0Nxd2dkM2g3N09OWWFjTkV1Y1wvd0lHeWhIM3A5TT0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIyMzU3YmU3Yy0zOWUwLTQ2MWUtOGQ4Zi05YTdhMDAzYzI5NGQiLCJhdWQiOiJxNHBwdTQwNHNkaXFsY2pnMjE3NTZodmFwIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImV2ZW50X2lkIjoiOTI5MDNlNGItNWI4My0xMWU4LWEyYmItMGI4MmE1MzZlNDUwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1MjY3NDgxMjksImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0xXzI3V2NNTDlrOCIsImNvZ25pdG86dXNlcm5hbWUiOiJkOWFlYWFkYy1lNjc3LTRjNjUtOWQ2OS1hNGQ2ZjNhN2RmODYiLCJleHAiOjE1MjY3NjcxNTMsImlhdCI6MTUyNjc2MzU1MywiZW1haWwiOiJ1c2VyQGV4YW1wbGUuY29tIn0.NTkpdSzIrNPbPjpycf5FT9hm5oXos6muvAt8oihrgELq6eUizn0xZFOlj6zuCbsmpOgYOHrlghdWvoPSwRDLt77ku4qQey4m_IwfaQ2gLM1LT3Ga-qN5Y_DXVOn3C8tNVJtGxM7WeFvJAbnCX4jCD_Z2LEmnRoSTMpIgwnNzWyAcOKTDEzEvqnK84P0jw1Nxv_G1uxAmmZjkSIJyCt8xVmdCAgCF6CnpqB8uHvWpc8VsfethY2QFH9UT8lDZ_ZoiPmp4oU2YEUR6g0NGzwwwazvhey8mUQfsyJoUKrRc2MYFHQoh9BX4yKUNaiWc18nrKEJPmEUeUtqHHMs7upR7Tw',
+      'cache-control': 'no-cache',
+      'CloudFront-Forwarded-Proto': 'https',
+      'CloudFront-Is-Desktop-Viewer': 'true',
+      'CloudFront-Is-Mobile-Viewer': 'false',
+      'CloudFront-Is-SmartTV-Viewer': 'false',
+      'CloudFront-Is-Tablet-Viewer': 'false',
+      'CloudFront-Viewer-Country': 'US',
+      'X-Amz-Cf-Id': 'qjuHdioMr3Wkv729dJAoAcTANhDn9d0n53oVxfXCEGo8t1Vh0r7q1w==',
+      'X-Amzn-Trace-Id': 'Root=1-5b009021-d0ad8066c32a016ee9408428',
+      'X-Forwarded-For': '',
+      'X-Forwarded-Port': '443',
+      'X-Forwarded-Proto': 'https',
+      ...req.headers,
+    },
+    queryStringParameters: null,
+    pathParameters: null,
+    stageVariables: null,
+    requestContext: {
+      resourceId: 'i0vjwq',
+      authorizer: {
+        claims: {
+          sub: '2357be7c-39e0-461e-8d8f-9a7a003c294d',
+          aud: 'q4ppu404sdiqlcjg21756hvap',
+          email_verified: 'true',
+          event_id: '92903e4b-5b83-11e8-a2bb-0b82a536e450',
+          token_use: 'id',
+          auth_time: '1526748129',
+          iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_27WcML9k8',
+          'cognito:username': 'd9aeaadc-e677-4c65-9d69-a4d6f3a7df86',
+          exp: 'Sat May 19 21:59:13 UTC 2018',
+          iat: 'Sat May 19 20:59:13 UTC 2018',
+          email: 'user@example.com',
+        },
+      },
+      resourcePath: req.url,
+      httpMethod: req.method,
+      extendedRequestId: 'HJt1SE01iYcFTFg=',
+      requestTime: '19/May/2018:20:59:13 +0000',
+      path: req.url,
+      accountId: '229055845648',
+      protocol: 'HTTP/1.1',
+      stage: 'dev',
+      requestTimeEpoch: 1526763553830,
+      requestId: '7c534d29-5ba7-11e8-8b53-01a096ccb37d',
+      identity: {
+        cognitoIdentityPoolId: null,
+        accountId: null,
+        cognitoIdentityId: null,
+        caller: null,
+        sourceIp: '161.97.247.158',
+        accessKey: null,
+        cognitoAuthenticationType: null,
+        cognitoAuthenticationProvider: null,
+        userArn: null,
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3432.3 Safari/537.36',
+        user: null,
+      },
+      apiId: 'mr1ssm7ne1',
+    },
+    body,
+    isBase64Encoded: false,
+  };
+}
+
+function createHandler(functions) {
+  const serverlessRoot = findServerlessPath(module.parent);
+  const pathMapping = Object.values(functions).reduce((sum, func) => {
+    const httpEvent = (func.events || []).find(event => 'http' in event);
+    if (!httpEvent) {
+      return sum;
+    }
+
+    const {
+      http: { path: httpPath, method },
+    } = httpEvent;
+    const [handlerPath, handlerExport] = func.handler.split('.');
+    // eslint-disable-next-line
+    const handlerModule = require(path.join(serverlessRoot, handlerPath));
+    const handler = handlerModule[handlerExport];
+    const resolvedPath = path.join('/', httpPath);
+
+    // eslint-disable-next-line
+    sum[resolvedPath] = sum[resolvedPath] || [];
+    sum[resolvedPath].push({
+      method,
+      handler,
+    });
+
+    return sum;
+  }, {});
+
+  return async (req, res) => {
+    const handlers = pathMapping[path.normalize(req.url)];
+    if (!handlers) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    const handler =
+      handlers.find(handle => handle.method.toLowerCase() === req.method.toLowerCase());
+    if (!handler) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    const event = await convertRequestToLambdaRequest(req);
+    const {
+      body = '',
+      statusCode = 200,
+      headers = {},
+    } = await util.promisify(handler.handler)(event, {});
+
+    Object.entries(headers).forEach(([key, value]) => {
+      res.setHeader(key, value);
+    });
+    res.writeHead(statusCode);
+    res.end(body);
+  };
+}
+
+const lambdaHttp = () => {
+  // load serverless to configure services.
+  const { functions } = findServerless(module);
+
+  const result = {};
+
+  beforeEach(async () => {
+    result.server = http.createServer(createHandler(functions));
+    result.server.listen(0);
+    await e2p(result.server, 'listening');
+    const { port } = result.server.address();
+    result.urls = Object.keys(functions).reduce((sum, key) => {
+      const func = functions[key];
+      // XXX: We only support a single http event per function.
+      const httpEvent = (func.events || []).find(event => 'http' in event);
+      if (!httpEvent) {
+        return sum;
+      }
+
+      return {
+        ...sum,
+        [key]: `http://localhost:${port}/${httpEvent.http.path}`,
+      };
+    }, {});
+  });
+
+  return result;
+};
+
+module.exports = lambdaHttp;

--- a/packages/aws-utils/package.json
+++ b/packages/aws-utils/package.json
@@ -3,9 +3,14 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "bin": {
+    "./bin/createCognitoUser.js": "createCognitoUser"
+  },
   "dependencies": {
+    "amazon-cognito-identity-js": "^2.0.6",
     "aws-sdk": "^2.238.1",
     "js-yaml": "^3.11.0",
+    "node-fetch": "^2.1.2",
     "pkg-up": "^2.0.0",
     "uuid": "^3.2.1"
   }

--- a/packages/aws-utils/package.json
+++ b/packages/aws-utils/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "amazon-cognito-identity-js": "^2.0.6",
+    "@conduitvc/config": "^1.0.0",
     "aws-sdk": "^2.238.1",
     "js-yaml": "^3.11.0",
     "node-fetch": "^2.1.2",

--- a/packages/aws-utils/package.json
+++ b/packages/aws-utils/package.json
@@ -7,9 +7,10 @@
     "./bin/createCognitoUser.js": "createCognitoUser"
   },
   "dependencies": {
-    "amazon-cognito-identity-js": "^2.0.6",
     "@conduitvc/config": "^1.0.0",
+    "amazon-cognito-identity-js": "^2.0.6",
     "aws-sdk": "^2.238.1",
+    "event-to-promise": "^0.8.0",
     "js-yaml": "^3.11.0",
     "node-fetch": "^2.1.2",
     "pkg-up": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,12 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.44"
 
+"@babel/code-frame@^7.0.0-beta.35", "@babel/code-frame@^7.0.0-beta.46":
+  version "7.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.47.tgz#d18c2f4c4ba8d093a2bcfab5616593bfe2441a27"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.47"
+
 "@babel/generator@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.44.tgz#c7e67b9b5284afcf69b309b50d7d37f3e5033d42"
@@ -41,6 +47,14 @@
 "@babel/highlight@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.44.tgz#18c94ce543916a80553edcdcf681890b200747d5"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/highlight@7.0.0-beta.47":
+  version "7.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.47.tgz#8fbc83fb2a21f0bd2b95cdbeb238cf9689cad494"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
@@ -130,6 +144,14 @@ align-text@^0.1.1, align-text@^0.1.3:
     kind-of "^3.0.2"
     longest "^1.0.1"
     repeat-string "^1.5.2"
+
+amazon-cognito-identity-js@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/amazon-cognito-identity-js/-/amazon-cognito-identity-js-2.0.6.tgz#a98ab8df96e3f0205e0ddad5c75360fdfcd45e5b"
+  dependencies:
+    buffer "4.9.1"
+    crypto-browserify "1.0.9"
+    js-cookie "^2.1.4"
 
 amdefine@>=0.0.4:
   version "1.0.1"
@@ -803,6 +825,10 @@ cryptiles@3.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
   dependencies:
     boom "5.x.x"
+
+crypto-browserify@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-1.0.9.tgz#cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
@@ -2250,6 +2276,10 @@ jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
 
+js-cookie@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
+
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -2617,6 +2647,10 @@ needle@^2.2.0:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
     sax "^1.2.4"
+
+node-fetch@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
 node-int64@^0.4.0:
   version "0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,6 +1148,10 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+event-to-promise@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/event-to-promise/-/event-to-promise-0.8.0.tgz#4b84f11772b6f25f7752fc74d971531ac6f5b626"
+
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"


### PR DESCRIPTION
This is some tooling so tests can test their lambda functions as easily as I could come up with while still being a very realistic environment. 

This bakes in credentials with the assumption that the checked in (expired) credentials will never be checked. This is fine as we run the cognito user checking via lambda itself and it's configured in serverless.

Example from the WIP file service.

```js

const lambdaHttp = require('@conduitvc/aws-utils/lambdaHttp');
const fetch = require('node-fetch');

describe('/graphql', function() {
  let server = lambdaHttp();

  it('should work', async () => {
    const res = await fetch(server.urls.graphql, {
      method: 'POST',
      body: JSON.stringify('foo'),
      headers: {
        SupDude: 'foo',
      },
    });
    console.log(await res.text());
  });
});


```