### PR TITLE
multiple subscriptions for one client

### DIFF
--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduitvc/appsync-emulator-serverless",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "schema.js",
   "license": "MIT",
   "bin": {

--- a/packages/appsync-emulator-serverless/serverCore.js
+++ b/packages/appsync-emulator-serverless/serverCore.js
@@ -32,25 +32,49 @@ class SubscriptionServer {
       this.onClientDisconnect(...args),
     );
 
-    // XXX: Note we may need to listen to unsubscribe to end the async iterator.
     mqttServer.on('subscribed', (...args) => this.onClientSubscribed(...args));
+    
+    mqttServer.on('unsubscribed', (...args) => this.onClientUnsubscribed(...args));
   }
 
   // eslint-disable-next-line
   async onClientConnect(client) {
     const { id: clientId } = client;
     consola.info(`client connected to subscription server (${clientId})`);
+    const timeout = this.iteratorTimeout.get(client.id)
+    if(timeout) { clearTimeout(timeout) }
   }
 
   async onClientSubscribed(topic, client) {
     const { id: clientId } = client;
     consola.info(`client (${clientId}) subscribed to : ${topic}`);
     log.info(`client (${clientId}) subscribed to : ${topic}`);
-    const reg = this.registrations.get(clientId);
-    if (!reg) {
+    const regs = this.registrations.get(clientId);
+    if (!regs) {
       console.error('No registration for clientId', clientId);
       return;
     }
+    
+    const reg = regs.find(({topicId}) => topicId === topic);
+    if (!reg) {
+      console.error(`Not subscribed to topicId: ${topic} for clientId`, clientId);
+      return;
+    }
+
+    if(!reg.isRegistered) {
+      const asyncIterator = await this.subscribeToGraphQL(reg);
+
+      if (asyncIterator.errors) {
+        console.error('Error(s) subcribing via graphql', asyncIterator.errors);
+        return;
+      }
+
+      Object.assign(reg, {
+        asyncIterator,
+        isRegistered: true,
+      })
+    }
+
     const { asyncIterator, topicId } = reg;
     log.info('clientConnect', { clientId, topicId });
 
@@ -80,6 +104,27 @@ class SubscriptionServer {
     }
   }
 
+  onClientUnsubscribed(topic, client) {
+    const { id: clientId } = client;
+    consola.info(`client (${clientId}) unsubscribed to : ${topic}`);
+    log.info(`client (${clientId}) unsubscribed to : ${topic}`);
+    const regs = this.registrations.get(clientId);
+    if (!regs) {
+      console.warn('Unsubscribe topic from client with unknown id', clientId);
+      return;
+    }
+
+    const reg = regs.find(({topicId}) => topicId === topic)
+    if (!reg) {
+      console.warn('Unsubscribe topic from client without existing subscription', clientId);
+      return;
+    }
+
+    //this.registrations.set(clientId, regs.filter(({topicId}) => topicId !== topic))
+    reg.asyncIterator.return()
+    reg.isRegistered = false;
+  }
+
   onClientDisconnect(client) {
     const { id: clientId } = client;
     log.info('clientDisconnect', { clientId });
@@ -89,22 +134,31 @@ class SubscriptionServer {
       console.warn('Disconnecting client with unknown id', clientId);
       return;
     }
-    this.registrations.delete(clientId);
-    reg.asyncIterator.return();
+    //this.registrations.delete(clientId);
+    //reg.asyncIterator.return();
   }
 
   async register({ documentAST, variables, jwt }) {
-    const clientId = uuid();
+    const clientId = jwt.sub;
     const topicId = uuid();
     log.info('register', { clientId, topicId });
 
     const context = { jwt };
+    const registration = {
+      context,
+      documentAST,
+      variables,
+      topicId,
+    };
+    const asyncIterator = await this.subscribeToGraphQL(registration);
+    /* 
     const asyncIterator = await subscribe({
       schema: this.schema,
       document: documentAST,
       variableValues: variables,
-      contextValue: { jwt },
+      contextValue: context,
     });
+    */
 
     if (asyncIterator.errors) {
       return {
@@ -113,12 +167,15 @@ class SubscriptionServer {
       };
     }
 
-    this.registrations.set(clientId, {
-      documentAST,
-      variables,
-      topicId,
+    Object.assign(registration, {
       asyncIterator,
-    });
+      isRegistered: true,
+    })
+
+    const currentRegistrations = this.registrations.get(clientId) || [];
+    currentRegistrations.push(registration);
+
+    this.registrations.set(clientId, currentRegistrations);
 
     // if client does not connect within this amount of time then end iterator.
     this.iteratorTimeout.set(
@@ -143,7 +200,7 @@ class SubscriptionServer {
           mqttConnections: [
             {
               url: this.mqttURL,
-              topics: [topicId],
+              topics: currentRegistrations.map(({topicId}) => topicId),
               client: clientId,
             },
           ],
@@ -158,6 +215,15 @@ class SubscriptionServer {
       data: null,
       errors: null,
     };
+  }
+
+  subscribeToGraphQL(registration) {
+    return subscribe({
+      schema: this.schema,
+      document: registration.documentAST,
+      variableValues: registration.variables,
+      contextValue: registration.context,
+    });
   }
 }
 

--- a/packages/appsync-emulator-serverless/serverCore.js
+++ b/packages/appsync-emulator-serverless/serverCore.js
@@ -117,7 +117,10 @@ class SubscriptionServer {
     log.info(`client (${clientId}) unsubscribed to : ${topic}`);
     const regs = this.registrations.get(clientId);
     if (!regs) {
-      console.warn(`Unsubscribe topic: ${topic} from client with unknown id`, clientId);
+      console.warn(
+        `Unsubscribe topic: ${topic} from client with unknown id`,
+        clientId,
+      );
       return;
     }
 

--- a/packages/appsync-emulator-serverless/serverCore.js
+++ b/packages/appsync-emulator-serverless/serverCore.js
@@ -33,16 +33,20 @@ class SubscriptionServer {
     );
 
     mqttServer.on('subscribed', (...args) => this.onClientSubscribed(...args));
-    
-    mqttServer.on('unsubscribed', (...args) => this.onClientUnsubscribed(...args));
+
+    mqttServer.on('unsubscribed', (...args) =>
+      this.onClientUnsubscribed(...args),
+    );
   }
 
   // eslint-disable-next-line
   async onClientConnect(client) {
     const { id: clientId } = client;
     consola.info(`client connected to subscription server (${clientId})`);
-    const timeout = this.iteratorTimeout.get(client.id)
-    if(timeout) { clearTimeout(timeout) }
+    const timeout = this.iteratorTimeout.get(client.id);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
   }
 
   async onClientSubscribed(topic, client) {
@@ -54,14 +58,17 @@ class SubscriptionServer {
       console.error('No registration for clientId', clientId);
       return;
     }
-    
-    const reg = regs.find(({topicId}) => topicId === topic);
+
+    const reg = regs.find(({ topicId }) => topicId === topic);
     if (!reg) {
-      console.error(`Not subscribed to topicId: ${topic} for clientId`, clientId);
+      console.error(
+        `Not subscribed to topicId: ${topic} for clientId`,
+        clientId,
+      );
       return;
     }
 
-    if(!reg.isRegistered) {
+    if (!reg.isRegistered) {
       const asyncIterator = await this.subscribeToGraphQL(reg);
 
       if (asyncIterator.errors) {
@@ -72,7 +79,7 @@ class SubscriptionServer {
       Object.assign(reg, {
         asyncIterator,
         isRegistered: true,
-      })
+      });
     }
 
     const { asyncIterator, topicId } = reg;
@@ -114,14 +121,17 @@ class SubscriptionServer {
       return;
     }
 
-    const reg = regs.find(({topicId}) => topicId === topic)
+    const reg = regs.find(({ topicId }) => topicId === topic);
     if (!reg) {
-      console.warn('Unsubscribe topic from client without existing subscription', clientId);
+      console.warn(
+        'Unsubscribe topic from client without existing subscription',
+        clientId,
+      );
       return;
     }
 
-    //this.registrations.set(clientId, regs.filter(({topicId}) => topicId !== topic))
-    reg.asyncIterator.return()
+    // this.registrations.set(clientId, regs.filter(({topicId}) => topicId !== topic))
+    reg.asyncIterator.return();
     reg.isRegistered = false;
   }
 
@@ -132,10 +142,9 @@ class SubscriptionServer {
     const reg = this.registrations.get(clientId);
     if (!reg) {
       console.warn('Disconnecting client with unknown id', clientId);
-      return;
     }
-    //this.registrations.delete(clientId);
-    //reg.asyncIterator.return();
+    // this.registrations.delete(clientId);
+    // reg.asyncIterator.return();
   }
 
   async register({ documentAST, variables, jwt }) {
@@ -170,7 +179,7 @@ class SubscriptionServer {
     Object.assign(registration, {
       asyncIterator,
       isRegistered: true,
-    })
+    });
 
     const currentRegistrations = this.registrations.get(clientId) || [];
     currentRegistrations.push(registration);
@@ -200,7 +209,7 @@ class SubscriptionServer {
           mqttConnections: [
             {
               url: this.mqttURL,
-              topics: currentRegistrations.map(({topicId}) => topicId),
+              topics: currentRegistrations.map(reg => reg.topicId),
               client: clientId,
             },
           ],

--- a/packages/appsync-emulator-serverless/serverCore.js
+++ b/packages/appsync-emulator-serverless/serverCore.js
@@ -117,20 +117,21 @@ class SubscriptionServer {
     log.info(`client (${clientId}) unsubscribed to : ${topic}`);
     const regs = this.registrations.get(clientId);
     if (!regs) {
-      console.warn('Unsubscribe topic from client with unknown id', clientId);
+      console.warn(`Unsubscribe topic: ${topic} from client with unknown id`, clientId);
       return;
     }
 
     const reg = regs.find(({ topicId }) => topicId === topic);
     if (!reg) {
       console.warn(
-        'Unsubscribe topic from client without existing subscription',
+        `Unsubscribe unregistered topic ${topic} from client`,
         clientId,
       );
       return;
     }
 
-    // this.registrations.set(clientId, regs.filter(({topicId}) => topicId !== topic))
+    // turn off subscription, but keep registration so client
+    // can resubscribe
     reg.asyncIterator.return();
     reg.isRegistered = false;
   }
@@ -143,8 +144,6 @@ class SubscriptionServer {
     if (!reg) {
       console.warn('Disconnecting client with unknown id', clientId);
     }
-    // this.registrations.delete(clientId);
-    // reg.asyncIterator.return();
   }
 
   async register({ documentAST, variables, jwt }) {
@@ -160,14 +159,6 @@ class SubscriptionServer {
       topicId,
     };
     const asyncIterator = await this.subscribeToGraphQL(registration);
-    /* 
-    const asyncIterator = await subscribe({
-      schema: this.schema,
-      document: documentAST,
-      variableValues: variables,
-      contextValue: context,
-    });
-    */
 
     if (asyncIterator.errors) {
       return {


### PR DESCRIPTION
-[x] handles multiple subs
-[] offline caching implementation

Not sure the best way to determine when to remove topics from registrations when the client is unsubscribing, disconnecting, reconnecting, resubscribing

