### PR TITLE
add CLI parameter to define a fixed port for dynamodb

### DIFF
--- a/packages/appsync-emulator-serverless/README.md
+++ b/packages/appsync-emulator-serverless/README.md
@@ -32,8 +32,9 @@ optional start dynamodb at a fixed port - e.g. 8000
 # NOTE unless you assign a specific port for dynamodb a random one will be chosen.
 yarn appsync-emulator --port 62222 --dynamodb-port 8000
 ```
-to access the dynamodb instance you need to use the following configuration:
+to access the dynamodb instance using javascript you need to use the following configuration:
 ```
+const { DynamoDB } = require('aws-sdk');
 const dynamodb = new DynamoDB({
   endpoint: 'http://localhost:8000',
   region: 'us-fake-1',

--- a/packages/appsync-emulator-serverless/README.md
+++ b/packages/appsync-emulator-serverless/README.md
@@ -25,6 +25,24 @@ This package will download and run the dynamodb emulator as part of it's appsync
 # NOTE unless you assign a specific port a random one will be chosen.
 yarn appsync-emulator --port 62222
 ```
+#### dynamodb with fixed port
+
+optional start dynamodb at a fixed port - e.g. 8000
+```sh
+# NOTE unless you assign a specific port for dynamodb a random one will be chosen.
+yarn appsync-emulator --port 62222 --dynamodb-port 8000
+```
+to access the dynamodb instance you need to use the following configuration:
+```
+const dynamodb = new DynamoDB({
+  endpoint: 'http://localhost:8000',
+  region: 'us-fake-1',
+  accessKeyId: 'fake',
+  secretAccessKey: 'fake',
+});
+const client = new DynamoDB.DocumentClient({ service: dynamodb });
+```
+
 
 ## Testing
 

--- a/packages/appsync-emulator-serverless/bin/server.js
+++ b/packages/appsync-emulator-serverless/bin/server.js
@@ -50,7 +50,7 @@ const main = async () => {
   const pkgPath = pkgUp.sync(serverlessPath);
   const emulator = await dynamoEmulator.launch({
     dbPath: path.join(path.dirname(pkgPath), '.dynamodb'),
-    port: dynamodbPort
+    port: dynamodbPort,
   });
   process.on('SIGINT', () => {
     // _ensure_ we do not leave java processes lying around.
@@ -63,15 +63,16 @@ const main = async () => {
   const serverless = path.join(path.dirname(pkgPath), 'serverless.yml');
   const server = await createServer({ serverless, port, dynamodb });
   console.log('started at url:', server.url);
-  dynamodb_port && console.log(
-    `dynamodb config:
+  if (dynamodbPort)
+    console.log(
+      `dynamodb config:
     {
       endpoint: 'http://localhost:${dynamodbPort}',
       region: 'us-fake-1',
       accessKeyId: 'fake',
       secretAccessKey: 'fake',
-    }`
-  );
+    }`,
+    );
 };
 
 main().catch(err => {

--- a/packages/appsync-emulator-serverless/bin/server.js
+++ b/packages/appsync-emulator-serverless/bin/server.js
@@ -39,9 +39,9 @@ const main = async () => {
     type: 'int',
   });
   // argparse converts any argument with a dash to underscores
-  /* eslint-disable camelcase */
+  // eslint-disable-next-line
   let { port, path: serverlessPath, dynamodb_port: dynamodbPort } = parser.parseArgs();
-  /* eslint-enable camelcase */
+
   port = port || 0;
   serverlessPath = serverlessPath || process.cwd();
   dynamodbPort = dynamodbPort || null;

--- a/packages/appsync-emulator-serverless/bin/server.js
+++ b/packages/appsync-emulator-serverless/bin/server.js
@@ -66,7 +66,7 @@ const main = async () => {
   dynamodb_port && console.log(
     `dynamodb config:
     {
-      endpoint: 'http://localhost:${dynamodb_port}',
+      endpoint: 'http://localhost:${dynamodbPort}',
       region: 'us-fake-1',
       accessKeyId: 'fake',
       secretAccessKey: 'fake',

--- a/packages/appsync-emulator-serverless/bin/server.js
+++ b/packages/appsync-emulator-serverless/bin/server.js
@@ -38,10 +38,10 @@ const main = async () => {
     help: 'Port to bind the dynamodb to (default is any free port)',
     type: 'int',
   });
-  /*eslint-disable camelcase*/
   // argparse converts any argument with a dash to underscores
+  /* eslint camelcase: ["error", {ignoreDestructuring: true}] */
   let { port, path: serverlessPath, dynamodb_port: dynamodbPort } = parser.parseArgs();
-  /*eslint-enable camelcase*/
+
   port = port || 0;
   serverlessPath = serverlessPath || process.cwd();
   dynamodbPort = dynamodbPort || null;

--- a/packages/appsync-emulator-serverless/bin/server.js
+++ b/packages/appsync-emulator-serverless/bin/server.js
@@ -38,8 +38,10 @@ const main = async () => {
     help: 'Port to bind the dynamodb to (default is any free port)',
     type: 'int',
   });
-
+  /*eslint-disable camelcase*/
+  // argparse converts any argument with a dash to underscores
   let { port, path: serverlessPath, dynamodb_port: dynamodbPort } = parser.parseArgs();
+  /*eslint-enable camelcase*/
   port = port || 0;
   serverlessPath = serverlessPath || process.cwd();
   dynamodbPort = dynamodbPort || null;

--- a/packages/appsync-emulator-serverless/bin/server.js
+++ b/packages/appsync-emulator-serverless/bin/server.js
@@ -39,9 +39,9 @@ const main = async () => {
     type: 'int',
   });
   // argparse converts any argument with a dash to underscores
-  /* eslint camelcase: ["error", {ignoreDestructuring: true}] */
+  /* eslint-disable camelcase */
   let { port, path: serverlessPath, dynamodb_port: dynamodbPort } = parser.parseArgs();
-
+  /* eslint-enable camelcase */
   port = port || 0;
   serverlessPath = serverlessPath || process.cwd();
   dynamodbPort = dynamodbPort || null;

--- a/packages/appsync-emulator-serverless/bin/server.js
+++ b/packages/appsync-emulator-serverless/bin/server.js
@@ -39,16 +39,16 @@ const main = async () => {
     type: 'int',
   });
 
-  let { port, path: serverlessPath, dynamodb_port } = parser.parseArgs();
+  let { port, path: serverlessPath, dynamodb_port: dynamodbPort } = parser.parseArgs();
   port = port || 0;
   serverlessPath = serverlessPath || process.cwd();
-  dynamodb_port = dynamodb_port || null;
+  dynamodbPort = dynamodbPort || null;
 
   // start the dynamodb emulator
   const pkgPath = pkgUp.sync(serverlessPath);
   const emulator = await dynamoEmulator.launch({
     dbPath: path.join(path.dirname(pkgPath), '.dynamodb'),
-    port: dynamodb_port
+    port: dynamodbPort
   });
   process.on('SIGINT', () => {
     // _ensure_ we do not leave java processes lying around.

--- a/packages/appsync-emulator-serverless/bin/server.js
+++ b/packages/appsync-emulator-serverless/bin/server.js
@@ -62,8 +62,10 @@ const main = async () => {
 
   const serverless = path.join(path.dirname(pkgPath), 'serverless.yml');
   const server = await createServer({ serverless, port, dynamodb });
+  /* eslint-disable no-console */
   console.log('started at url:', server.url);
-  if (dynamodbPort)
+  if (dynamodbPort) {
+    /* eslint-disable no-console */
     console.log(
       `dynamodb config:
     {
@@ -73,6 +75,7 @@ const main = async () => {
       secretAccessKey: 'fake',
     }`,
     );
+  }
 };
 
 main().catch(err => {

--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduitvc/appsync-emulator-serverless",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "main": "schema.js",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
This commit resolves #21 and adds a new cli parameter to define a fixed port:
`--dynamodb-port <portnumber>`
