### PR TITLE
Fix/webpack functionality

### DIFF
--- a/packages/appsync-emulator-serverless/README.md
+++ b/packages/appsync-emulator-serverless/README.md
@@ -45,13 +45,12 @@ const client = new DynamoDB.DocumentClient({ service: dynamodb });
 ```
 
 #### Custom build prefix for webpack, typescript
-For compatibility with plugins such as Serverless Webpack that alllow the usage of webpack
-you will need to add the following configuration to your project's `serverless.yml` file
+For compatibility with plugins such as Serverless Webpack that allow the usage of webpack
+you will need to add the following configuration to your project's `serverless.yml` file.
 
 ```
 custom:
   appsync-offline:
-    port: $APPSYNC_OFFLINE_PORT
     buildPrefix: $PREFIX_LOCATION
 ```
 

--- a/packages/appsync-emulator-serverless/README.md
+++ b/packages/appsync-emulator-serverless/README.md
@@ -44,6 +44,18 @@ const dynamodb = new DynamoDB({
 const client = new DynamoDB.DocumentClient({ service: dynamodb });
 ```
 
+#### Custom build prefix for webpack, typescript
+For compatibility with plugins such as Serverless Webpack that alllow the usage of webpack
+you will need to add the following configuration to your project's `serverless.yml` file
+
+```
+custom:
+  appsync-offline:
+    port: $APPSYNC_OFFLINE_PORT
+    buildPrefix: $PREFIX_LOCATION
+```
+
+Where `$PREFIX_LOCATION` is your specified webpack build path i.e. `.webpack`
 
 ## Testing
 

--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -20,15 +20,15 @@ const lambdaSource = async (
   }
 
   // Default to empty string, path.join will resolve this automatically
-  let modulePrefix = '';
+  let buildPrefix = '';
 
   // Check if the modulePrefix configuration is set
-  if (custom['appsync-emulator'] && custom['appsync-emulator'].modulePrefix) {
-    ({ modulePrefix } = custom['appsync-emulator']);
+  if (custom['appsync-emulator'] && custom['appsync-emulator'].buildPrefix) {
+    ({ buildPrefix } = custom['appsync-emulator']);
   }
 
   const [handlerPath, handlerMethod] = fnConfig.handler.split('.');
-  const fullPath = path.join(serverlessDirectory, modulePrefix, handlerPath);
+  const fullPath = path.join(serverlessDirectory, buildPrefix, handlerPath);
   const dynamodbTableAliases = Object.entries(dynamodbTables).reduce(
     (sum, [alias, tableName]) => ({
       ...sum,

--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -8,7 +8,7 @@ const lambdaSource = async (
   {
     dynamodbEndpoint,
     dynamodbTables,
-    serverlessConfig: { functions },
+    serverlessConfig: { functions, config },
     serverlessDirectory,
   },
   fn,
@@ -19,8 +19,16 @@ const lambdaSource = async (
     throw new Error(`Cannot find function config for function : ${fn}`);
   }
 
+  // Default to empty string, path.join will resolve this automatically
+  let modulePrefix = '';
+
+  // Check if the modulePrefix configuration is set
+  if (config['appsync-emulator'] && config['appsync-emulator'].modulePrefix) {
+    [modulePrefix] = config['appsync-emulator'].modulePrefix;
+  }
+
   const [handlerPath, handlerMethod] = fnConfig.handler.split('.');
-  const fullPath = path.join(serverlessDirectory, handlerPath);
+  const fullPath = path.join(serverlessDirectory, modulePrefix, handlerPath);
   const dynamodbTableAliases = Object.entries(dynamodbTables).reduce(
     (sum, [alias, tableName]) => ({
       ...sum,

--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -8,7 +8,7 @@ const lambdaSource = async (
   {
     dynamodbEndpoint,
     dynamodbTables,
-    serverlessConfig: { functions, config },
+    serverlessConfig: { functions, custom },
     serverlessDirectory,
   },
   fn,
@@ -23,8 +23,8 @@ const lambdaSource = async (
   let modulePrefix = '';
 
   // Check if the modulePrefix configuration is set
-  if (config['appsync-emulator'] && config['appsync-emulator'].modulePrefix) {
-    ({ modulePrefix } = config['appsync-emulator']);
+  if (custom['appsync-emulator'] && custom['appsync-emulator'].modulePrefix) {
+    ({ modulePrefix } = custom['appsync-emulator']);
   }
 
   const [handlerPath, handlerMethod] = fnConfig.handler.split('.');

--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -8,7 +8,7 @@ const lambdaSource = async (
   {
     dynamodbEndpoint,
     dynamodbTables,
-    serverlessConfig: { functions, custom },
+    serverlessConfig: { functions = {}, custom = {} },
     serverlessDirectory,
   },
   fn,

--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -24,7 +24,7 @@ const lambdaSource = async (
 
   // Check if the modulePrefix configuration is set
   if (config['appsync-emulator'] && config['appsync-emulator'].modulePrefix) {
-    [modulePrefix] = config['appsync-emulator'].modulePrefix;
+    ({ modulePrefix } = config['appsync-emulator']);
   }
 
   const [handlerPath, handlerMethod] = fnConfig.handler.split('.');


### PR DESCRIPTION
As discussed in #30 this is a fix to work with serverless-webpack. This requires the modulePrefix option to be set in the `appsync-emulator` config in `serverless.yml` 