### PR TITLE
Move DynamoDB emulator to optional dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,5 +9,6 @@ module.exports = {
     'no-restricted-syntax': 0,
     'no-await-in-loop': 0,
     'no-return-assign': 0,
+    "import/no-extraneous-dependencies": ["error", {"optionalDependencies": true}]
   },
 };

--- a/packages/appsync-emulator-serverless/README.md
+++ b/packages/appsync-emulator-serverless/README.md
@@ -27,11 +27,11 @@ We aim to support the majority of appsync features (as we use all of them except
 
 
 ```
-npm i serverless-appsync-plugin [--no-optional]
+npm i @conduitvc/serverless-appsync-plugin [--no-optional]
 ```
 or
 ```
-yarn add serverless-appsync-plugin [--ignore-optional]
+yarn add @conduitvc/serverless-appsync-plugin [--ignore-optional]
 ```
 
 ## Usage

--- a/packages/appsync-emulator-serverless/README.md
+++ b/packages/appsync-emulator-serverless/README.md
@@ -14,10 +14,29 @@ We aim to support the majority of appsync features (as we use all of them except
  - Full VTL support ($util) and compatibility with Java stdlib
  - Support for use with cognito credentials
  - Subscriptions
+ 
+## Requirements
+
+- Java*
+
+*If installing DynamoDB Local.
+
+## Installation
+
+[DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html) is an optional dependency and installed by default. If you would rather provide your own DynamoDB server, you can instruct npm/yarn not to install optional dependencies.
+
+
+```
+npm i serverless-appsync-plugin [--no-optional]
+```
+or
+```
+yarn add serverless-appsync-plugin [--ignore-optional]
+```
 
 ## Usage
 
-This package will download and run the dynamodb emulator as part of it's appsync emulation features. DynamoDB data is preserved between emulator runs and is stored in `.dynamodb` in the same directory that `package.json` would be in.
+If using the DynamoDB emulator, data is preserved between emulator runs and is stored in `.dynamodb` in the same directory that `package.json` would be in.
 
 ### As a CLI
 

--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@conduitvc/aws-utils": "^1.2.1",
-    "@conduitvc/dynamodb-emulator": "^0.5.3",
     "@conduitvc/mosca": "^2.8.2",
     "@okgrow/graphql-scalars": "^0.4.2",
     "argparse": "^1.0.10",
@@ -44,5 +43,8 @@
   },
   "peerDependencies": {
     "aws-appsync": ">= 1"
+  },
+  "optionalDependencies": {
+    "@conduitvc/dynamodb-emulator": "^0.5.3"
   }
 }


### PR DESCRIPTION
This PR comes from two requirements in my setup. The first is that I don't use the emulator, so it makes sense to move to an optional dependency. The second is that I cannot use `appsync-emulator-serverless` inside a docker container that doesn't have `zip` installed. The DynamoDB emulator attempts to download and manipulate the emulator's JAR file with the zip command, which fails if the command isn't available. 

This PR pairs with [this PR](https://github.com/aheissenberger/serverless-appsync-offline/pull/5) and allows me to run `serverless-appsync-offline` within a docker container without zip installed and relying on localstack.