### PR TITLE
Change the custom field to appsync-offline for buildPrefix

### DIFF
--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -23,9 +23,9 @@ const lambdaSource = async (
   // Default to empty string, path.join will resolve this automatically
   let buildPrefix = '';
 
-  // Check if the modulePrefix configuration is set
-  if (custom['appsync-emulator'] && custom['appsync-emulator'].buildPrefix) {
-    ({ buildPrefix } = custom['appsync-emulator']);
+  // Check if the buildPrefix configuration is set
+  if (custom['appsync-offline'] && custom['appsync-offline'].buildPrefix) {
+    ({ buildPrefix } = custom['appsync-offline']);
   }
 
   const [handlerPath, handlerMethod] = fnConfig.handler.split('.');


### PR DESCRIPTION
In your README we can find the part about of configuration of build source with `custom/appsync-offline` path, but in the real code this path has another structure: `custom/appsync-emulator`.
I changed it.  