### PR TITLE
feat(lambdaRunner): Allow a lambda async

### DIFF
--- a/packages/appsync-emulator-serverless/__test__/lambdaFunctions.js
+++ b/packages/appsync-emulator-serverless/__test__/lambdaFunctions.js
@@ -1,0 +1,25 @@
+exports.callbackWithError = (event, context, callback) => {
+  callback('error', null);
+};
+
+exports.callbackWithOutput = (event, context, callback) => {
+  callback(null, true);
+};
+
+exports.asyncWithError = async () => {
+  throw new Error('error');
+};
+
+exports.asyncWithOutput = async () => true;
+
+exports.promiseWithError = () => (
+  new Promise((_, reject) => {
+    reject(new Error('error'));
+  })
+);
+
+exports.promiseWithOutput = () => (
+  new Promise(resolve => {
+    resolve(true);
+  })
+);

--- a/packages/appsync-emulator-serverless/__test__/lambdaFunctions.js
+++ b/packages/appsync-emulator-serverless/__test__/lambdaFunctions.js
@@ -12,14 +12,12 @@ exports.asyncWithError = async () => {
 
 exports.asyncWithOutput = async () => true;
 
-exports.promiseWithError = () => (
+exports.promiseWithError = () =>
   new Promise((_, reject) => {
     reject(new Error('error'));
-  })
-);
+  });
 
-exports.promiseWithOutput = () => (
+exports.promiseWithOutput = () =>
   new Promise(resolve => {
     resolve(true);
-  })
-);
+  });

--- a/packages/appsync-emulator-serverless/__test__/lambdaRunner.test.js
+++ b/packages/appsync-emulator-serverless/__test__/lambdaRunner.test.js
@@ -3,7 +3,7 @@ const { run } = require('../lambdaRunner');
 describe('lambdaRunner', () => {
   describe('run', () => {
     describe('callback', () => {
-      test('The lambda throws an error', async () => {
+      it('throws an error', async () => {
         const lambda = (event, context, callback) => {
           callback('error', null);
         };
@@ -14,7 +14,7 @@ describe('lambdaRunner', () => {
           expect(err).toMatch('error');
         });
       });
-      test('The lambda returns output', async () => {
+      it('returns output', async () => {
         const lambda = (event, context, callback) => {
           callback(null, true);
         };
@@ -28,7 +28,7 @@ describe('lambdaRunner', () => {
     });
 
     describe('async', () => {
-      test('The lambda throws an error', async () => {
+      it('throws an error', async () => {
         const lambda = async () => {
           throw new Error('error');
         };
@@ -41,7 +41,7 @@ describe('lambdaRunner', () => {
           expect(e.message).toMatch('error');
         }
       });
-      test('The lambda returns output', async () => {
+      it('returns output', async () => {
         const lambda = async () => true;
         const context = {};
         const payload = {};
@@ -52,7 +52,7 @@ describe('lambdaRunner', () => {
     });
 
     describe('promise', () => {
-      test('The lambda throws an error', async () => {
+      it('throws an error', async () => {
         const lambda = () =>
           new Promise((_, reject) => {
             reject(new Error());
@@ -66,7 +66,7 @@ describe('lambdaRunner', () => {
           expect(e).toBeInstanceOf(Error);
         }
       });
-      test('The lambda returns output', async () => {
+      it('returns output', async () => {
         const lambda = () =>
           new Promise(resolve => {
             resolve(true);

--- a/packages/appsync-emulator-serverless/__test__/lambdaRunner.test.js
+++ b/packages/appsync-emulator-serverless/__test__/lambdaRunner.test.js
@@ -10,11 +10,9 @@ describe('lambdaRunner', () => {
         const context = {};
         const payload = {};
 
-        try {
-          await run({ lambda, context, payload });
-        } catch (e) {
-          expect(e).toMatch('error');
-        }
+        run({ lambda, context, payload }, err => {
+          expect(err).toMatch('error')
+        });
       });
       test('The lambda returns output', async () => {
         const lambda = (event, context, callback) => {
@@ -23,8 +21,9 @@ describe('lambdaRunner', () => {
         const context = {};
         const payload = {};
 
-        const output = await run({ lambda, context, payload });
-        expect(output).toBe(true);
+        run({ lambda, context, payload }, (err, output) => {
+          expect(output).toBe(true)
+        });
       });
     });
 
@@ -49,5 +48,35 @@ describe('lambdaRunner', () => {
         expect(output).toBe(true);
       });
     });
+
+    describe('promise', () => {
+      test('The lambda throws an error', async () => {
+        const lambda = (event, context) => {
+          return new Promise((_, reject) => {
+            reject('error');
+          });
+        }
+        const context = {};
+        const payload = {};
+
+        try {
+          await run({ lambda, context, payload });
+        } catch (e) {
+          expect(e).toMatch('error');
+        }
+      });
+      test('The lambda returns output', async () => {
+        const lambda = (event, context) => {
+          return new Promise(resolve => {
+            resolve(true);
+          });
+        }
+        const context = {};
+        const payload = {};
+
+        const output = await run({ lambda, context, payload });
+        expect(output).toBe(true);
+      });
+    })
   });
 });

--- a/packages/appsync-emulator-serverless/__test__/lambdaRunner.test.js
+++ b/packages/appsync-emulator-serverless/__test__/lambdaRunner.test.js
@@ -11,7 +11,7 @@ describe('lambdaRunner', () => {
         const payload = {};
 
         run({ lambda, context, payload }, err => {
-          expect(err).toMatch('error')
+          expect(err).toMatch('error');
         });
       });
       test('The lambda returns output', async () => {
@@ -22,14 +22,16 @@ describe('lambdaRunner', () => {
         const payload = {};
 
         run({ lambda, context, payload }, (err, output) => {
-          expect(output).toBe(true)
+          expect(output).toBe(true);
         });
       });
     });
 
     describe('async', () => {
       test('The lambda throws an error', async () => {
-        const lambda = async (event, context) => { throw new Error('error'); };
+        const lambda = async () => {
+          throw new Error('error');
+        };
         const context = {};
         const payload = {};
 
@@ -40,7 +42,7 @@ describe('lambdaRunner', () => {
         }
       });
       test('The lambda returns output', async () => {
-        const lambda = async (event, context) => true
+        const lambda = async () => true;
         const context = {};
         const payload = {};
 
@@ -51,32 +53,30 @@ describe('lambdaRunner', () => {
 
     describe('promise', () => {
       test('The lambda throws an error', async () => {
-        const lambda = (event, context) => {
-          return new Promise((_, reject) => {
-            reject('error');
+        const lambda = () =>
+          new Promise((_, reject) => {
+            reject(new Error());
           });
-        }
         const context = {};
         const payload = {};
 
         try {
           await run({ lambda, context, payload });
         } catch (e) {
-          expect(e).toMatch('error');
+          expect(e).toBeInstanceOf(Error);
         }
       });
       test('The lambda returns output', async () => {
-        const lambda = (event, context) => {
-          return new Promise(resolve => {
+        const lambda = () =>
+          new Promise(resolve => {
             resolve(true);
           });
-        }
         const context = {};
         const payload = {};
 
         const output = await run({ lambda, context, payload });
         expect(output).toBe(true);
       });
-    })
+    });
   });
 });

--- a/packages/appsync-emulator-serverless/__test__/lambdaRunner.test.js
+++ b/packages/appsync-emulator-serverless/__test__/lambdaRunner.test.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { fork } = require('child_process');
 const e2p = require('event-to-promise');
+
 const Runner = path.join(__dirname, '../lambdaRunner');
 
 const run = ({ handlerMethod, payload = {} }) => {
@@ -16,7 +17,7 @@ const run = ({ handlerMethod, payload = {} }) => {
   });
 
   return e2p(child, 'message');
-}
+};
 
 describe('lambdaRunner', () => {
   describe('callback', () => {
@@ -40,15 +41,16 @@ describe('lambdaRunner', () => {
   describe('async', () => {
     it('throws an error', async () => {
       const response = await run({
-        handlerMethod: 'asyncWithError'
+        handlerMethod: 'asyncWithError',
       });
 
       expect(response.type).toBe('error');
-      expect(response.error).toBe('error');
+      expect(response.error).toHaveProperty('errorType', 'Error');
+      expect(response.error).toHaveProperty('errorMessage', 'error');
     });
     it('returns output', async () => {
       const response = await run({
-        handlerMethod: 'asyncWithOutput'
+        handlerMethod: 'asyncWithOutput',
       });
 
       expect(response.type).toBe('success');
@@ -59,15 +61,16 @@ describe('lambdaRunner', () => {
   describe('promise', () => {
     it('throws an error', async () => {
       const response = await run({
-        handlerMethod: 'promiseWithError'
+        handlerMethod: 'promiseWithError',
       });
 
       expect(response.type).toBe('error');
-      expect(response.error).toBe('error');
+      expect(response.error).toHaveProperty('errorType', 'Error');
+      expect(response.error).toHaveProperty('errorMessage', 'error');
     });
     it('returns output', async () => {
       const response = await run({
-        handlerMethod: 'promiseWithOutput'
+        handlerMethod: 'promiseWithOutput',
       });
 
       expect(response.type).toBe('success');

--- a/packages/appsync-emulator-serverless/__test__/lambdaRunner.test.js
+++ b/packages/appsync-emulator-serverless/__test__/lambdaRunner.test.js
@@ -1,0 +1,53 @@
+const { run } = require('../lambdaRunner');
+
+describe('lambdaRunner', () => {
+  describe('run', () => {
+    describe('callback', () => {
+      test('The lambda throws an error', async () => {
+        const lambda = (event, context, callback) => {
+          callback('error', null);
+        };
+        const context = {};
+        const payload = {};
+
+        try {
+          await run({ lambda, context, payload });
+        } catch (e) {
+          expect(e).toMatch('error');
+        }
+      });
+      test('The lambda returns output', async () => {
+        const lambda = (event, context, callback) => {
+          callback(null, true);
+        };
+        const context = {};
+        const payload = {};
+
+        const output = await run({ lambda, context, payload });
+        expect(output).toBe(true);
+      });
+    });
+
+    describe('async', () => {
+      test('The lambda throws an error', async () => {
+        const lambda = async (event, context) => { throw new Error('error'); };
+        const context = {};
+        const payload = {};
+
+        try {
+          await run({ lambda, context, payload });
+        } catch (e) {
+          expect(e.message).toMatch('error');
+        }
+      });
+      test('The lambda returns output', async () => {
+        const lambda = async (event, context) => true
+        const context = {};
+        const payload = {};
+
+        const output = await run({ lambda, context, payload });
+        expect(output).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/appsync-emulator-serverless/lambdaRunner.js
+++ b/packages/appsync-emulator-serverless/lambdaRunner.js
@@ -1,35 +1,38 @@
+const { promisify } = require('util');
 const log = require('logdown')('appsync-emulator:lambdaRunner');
+const { create: createUtils } = require('./util');
 
+const sendOutput = output => {
+  process.send({ type: 'success', output }, process.exit);
+}
 const sendErr = err => {
-  process.send({ type: 'error', error: err }, () => {
-    process.exit();
-  });
+  process.send({ type: 'error', error: err }, process.exit);
 };
 
-process.once('message', ({ module, handlerPath, handlerMethod, payload }) => {
+const run = async ({ lambda, context, payload }) => {
+  if (!createUtils().isAsync(lambda)) {
+    lambda = promisify(lambda);
+  }
+  const output = await lambda(payload, context);
+  return output;
+}
+
+process.once('message', async ({ module, handlerPath, handlerMethod, payload }) => {
   try {
     log.info('load', module);
     // eslint-disable-next-line
     const handlerModule = require(module);
     if (!handlerModule[handlerMethod]) {
-      sendErr(
-        new Error(
-          `Module : ${handlerPath} does not have export: ${handlerMethod}`,
-        ),
+      throw new Error(
+        `Module : ${handlerPath} does not have export: ${handlerMethod}`,
       );
     }
 
     log.info('invoke', handlerMethod);
+    const lambda = handlerModule[handlerMethod];
     const context = {};
-    handlerModule[handlerMethod](payload, context, (err, output) => {
-      if (err) {
-        sendErr(err);
-        return;
-      }
-      process.send({ type: 'success', output }, () => {
-        process.exit();
-      });
-    });
+    const output = await run({ lambda, context, payload });
+    sendOutput(output);
   } catch (err) {
     sendErr(err);
   }
@@ -43,3 +46,7 @@ process.on('unhandledRejection', err => {
   log.error('unhandledRejection in lambda', err);
   process.exit(1);
 });
+
+module.exports = {
+  run,
+};

--- a/packages/appsync-emulator-serverless/lambdaRunner.js
+++ b/packages/appsync-emulator-serverless/lambdaRunner.js
@@ -1,44 +1,50 @@
-const { promisify } = require('util');
 const log = require('logdown')('appsync-emulator:lambdaRunner');
 const { create: createUtils } = require('./util');
 
 const sendOutput = output => {
   process.send({ type: 'success', output }, process.exit);
-}
+};
 const sendErr = err => {
   process.send({ type: 'error', error: err }, process.exit);
 };
 
 const run = async ({ lambda, context, payload }, callback) => {
-  const output = lambda(payload, context, callback)
+  const output = lambda(payload, context, callback);
 
-  if (createUtils().isPromise(output)) {
-    return await output;
-  }
-}
+  if (!createUtils().isPromise(output)) return;
+  const promiseOutput = await output;
+  return promiseOutput;
+};
 
-process.once('message', async ({ module, handlerPath, handlerMethod, payload }) => {
-  try {
-    log.info('load', module);
-    // eslint-disable-next-line
-    const handlerModule = require(module);
-    if (!handlerModule[handlerMethod]) {
-      throw new Error(
-        `Module : ${handlerPath} does not have export: ${handlerMethod}`,
+process.once(
+  'message',
+  async ({ module, handlerPath, handlerMethod, payload }) => {
+    try {
+      log.info('load', module);
+      // eslint-disable-next-line
+      const handlerModule = require(module);
+      if (!handlerModule[handlerMethod]) {
+        throw new Error(
+          `Module : ${handlerPath} does not have export: ${handlerMethod}`,
+        );
+      }
+
+      log.info('invoke', handlerMethod);
+      const lambda = handlerModule[handlerMethod];
+      const context = {};
+      const promiseOutput = run(
+        { lambda, context, payload },
+        (err, callbackOutput) => {
+          if (err) sendErr(err);
+          sendOutput(callbackOutput);
+        },
       );
+      sendOutput(await promiseOutput);
+    } catch (err) {
+      sendErr(err);
     }
-
-    log.info('invoke', handlerMethod);
-    const lambda = handlerModule[handlerMethod];
-    const context = {};
-    const output = await run({ lambda, context, payload }, (err, output) => {
-      err ? sendErr(err) : sendOutput(output)
-    });
-    sendOutput(output);
-  } catch (err) {
-    sendErr(err);
-  }
-});
+  },
+);
 
 process.on('uncaughtException', err => {
   log.error('uncaughtException in lambda', err);

--- a/packages/appsync-emulator-serverless/lambdaRunner.js
+++ b/packages/appsync-emulator-serverless/lambdaRunner.js
@@ -39,7 +39,7 @@ process.once(
           sendOutput(callbackOutput);
         },
       );
-      sendOutput(await promiseOutput);
+      if (promiseOutput) sendOutput(await promiseOutput);
     } catch (err) {
       sendErr(err);
     }

--- a/packages/appsync-emulator-serverless/lambdaRunner.js
+++ b/packages/appsync-emulator-serverless/lambdaRunner.js
@@ -11,10 +11,10 @@ const sendOutput = output => {
 };
 const sendErr = err => {
   let error;
-  if (err.stack) {
+  if (err instanceof Error) {
     error = {
       stackTrace: parseErrorStack(err),
-      errorType: err.name,
+      errorType: err.constructor.name,
       errorMessage: err.message,
     };
   } else {

--- a/packages/appsync-emulator-serverless/util.js
+++ b/packages/appsync-emulator-serverless/util.js
@@ -101,6 +101,9 @@ const create = (errors = [], now = new Date()) => ({
     if (value instanceof Map) return value;
     return value != null && typeof value === 'object';
   },
+  isAsync(fn) {
+    return fn.constructor.name === 'AsyncFunction';
+ },
   typeOf(value) {
     if (value === null) return 'Null';
     if (this.isList(value)) return 'List';

--- a/packages/appsync-emulator-serverless/util.js
+++ b/packages/appsync-emulator-serverless/util.js
@@ -105,9 +105,11 @@ const create = (errors = [], now = new Date()) => ({
     return fn.constructor.name === 'AsyncFunction';
   },
   isPromise(obj) {
-    return !!obj
-      && (typeof obj === 'object' || typeof obj === 'function')
-      && typeof obj.then === 'function';
+    return (
+      !!obj &&
+      (typeof obj === 'object' || typeof obj === 'function') &&
+      typeof obj.then === 'function'
+    );
   },
   typeOf(value) {
     if (value === null) return 'Null';

--- a/packages/appsync-emulator-serverless/util.js
+++ b/packages/appsync-emulator-serverless/util.js
@@ -103,7 +103,12 @@ const create = (errors = [], now = new Date()) => ({
   },
   isAsync(fn) {
     return fn.constructor.name === 'AsyncFunction';
- },
+  },
+  isPromise(obj) {
+    return !!obj
+      && (typeof obj === 'object' || typeof obj === 'function')
+      && typeof obj.then === 'function';
+  },
   typeOf(value) {
     if (value === null) return 'Null';
     if (this.isList(value)) return 'List';

--- a/packages/appsync-emulator-serverless/util.js
+++ b/packages/appsync-emulator-serverless/util.js
@@ -101,16 +101,6 @@ const create = (errors = [], now = new Date()) => ({
     if (value instanceof Map) return value;
     return value != null && typeof value === 'object';
   },
-  isAsync(fn) {
-    return fn.constructor.name === 'AsyncFunction';
-  },
-  isPromise(obj) {
-    return (
-      !!obj &&
-      (typeof obj === 'object' || typeof obj === 'function') &&
-      typeof obj.then === 'function'
-    );
-  },
   typeOf(value) {
     if (value === null) return 'Null';
     if (this.isList(value)) return 'List';


### PR DESCRIPTION
https://aws.amazon.com/ko/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/

There are 3 async pattern.

1. `async (event, context) => { return ... }`
2. `(event, context, callback) => { callback(...) }`
3. `(event, context) => { return new Promise(...) }`