### PR TITLE
Fix issue with DynamoDB list field

### DIFF
--- a/packages/appsync-emulator-serverless/__test__/example/schema.graphql
+++ b/packages/appsync-emulator-serverless/__test__/example/schema.graphql
@@ -80,11 +80,13 @@ type QuoteRequest {
   id: ID!
   commodity: String
   amount: Float
+  tags: [String]
 }
 
 input QuoteRequestInput {
   commodity: String
   amount: Float
+  tags: [String]
 }
 
 type QuoteResponse {

--- a/packages/appsync-emulator-serverless/__test__/schemaTest.test.js
+++ b/packages/appsync-emulator-serverless/__test__/schemaTest.test.js
@@ -4,7 +4,7 @@ const { subscribe } = require('graphql/subscription');
 const gql = require('graphql-tag');
 const { decoded: jwt } = require('../testJWT');
 const nock = require('nock');
-// const dynamodbEmulator = require('@conduitvc/dynamodb-emulator/client');
+const dynamodbEmulator = require('@conduitvc/dynamodb-emulator/client');
 
 const getScalarSource = (field, val) => `
   query {
@@ -22,23 +22,16 @@ describe('creates executable schema', () => {
   const schemaPath = `${__dirname}/example/schema.graphql`;
   let contextValue;
 
-  // let emulator;
+  let emulator;
   let dynamodb;
   beforeAll(async () => {
     jest.setTimeout(40 * 1000);
-    // emulator = await dynamodbEmulator.launch();
-    // dynamodb = dynamodbEmulator.getClient(emulator);
-    const { DynamoDB } = require('aws-sdk');
-    dynamodb = new DynamoDB({
-      endpoint: 'http://localhost:8001',
-      region: 'us-fake-1',
-      accessKeyId: 'fake',
-      secretAccessKey: 'fake',
-    });
+    emulator = await dynamodbEmulator.launch();
+    dynamodb = dynamodbEmulator.getClient(emulator);
   });
 
   afterAll(async () => {
-    // await emulator.terminate();
+    await emulator.terminate();
   });
   // eslint-disable-next-line
   let schema, close;

--- a/packages/appsync-emulator-serverless/dynamodbSource.js
+++ b/packages/appsync-emulator-serverless/dynamodbSource.js
@@ -7,10 +7,21 @@ const nullIfEmpty = obj => (Object.keys(obj).length === 0 ? null : obj);
 const unmarshall = (raw, isRaw = true) => {
   const content = isRaw ? Converter.unmarshall(raw) : raw;
 
-  // because of the funky set type used in the aws-sdk we need to further unwrap
+  // Because of the funky set type used in the aws-sdk, we need to further unwrap
   // to find if there is a set that needs to be unpacked into an array.
+
+  // Unwrap sets
   if (content && typeof content === 'object' && content.wrapperName === 'Set') {
     return content.values;
+  }
+
+  // Unwrap lists
+  if (
+    content &&
+    typeof content === 'object' &&
+    Object.keys(content).includes('0')
+  ) {
+    return Object.values(content);
   }
 
   if (content && typeof content === 'object') {

--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduitvc/appsync-emulator-serverless",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "main": "schema.js",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
The `aws-sdk-js` library has some funky handling of DyanmoDB sets and lists. While `appsync-emulator-serverless` correctly handles the weird handling of sets, it doesn't correctly handle lists. It returns lists as objects with numeric keys instead of proper arrays (for example `{"0": "foo", "1": "bar"}`). I believe I have a way to solve this, but first I'm going to add tests that demonstrate the issue.