### PR TITLE
Pass process.env to javascript lambdas

### DIFF
--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -57,6 +57,7 @@ const lambdaSource = async (
   } else {
     child = fork(Runner, [], {
       env: {
+        ...process.env,
         ...dynamodbTableAliases,
         DYNAMODB_ENDPOINT: dynamodbEndpoint,
       },


### PR DESCRIPTION
When the child process is created for Python Lambdas the parents process.env is passed down. The javascript lambdas were missing this line of code, making testing lambdas that require env variables difficult.