### PR TITLE
Bump Appsync-Emulator-Serverless version

### DIFF
--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduitvc/appsync-emulator-serverless",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "main": "schema.js",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Bump version to be able to use it with npm install