### PR TITLE
Fix JavaMap .values() and .entrySet()

### DIFF
--- a/packages/appsync-emulator-serverless/vtl.js
+++ b/packages/appsync-emulator-serverless/vtl.js
@@ -127,7 +127,7 @@ class JavaMap {
   }
 
   entrySet() {
-    return new JavaArray(this.map.values());
+    return new JavaArray(Array.from(this.map.values()));
   }
 
   equals(value) {
@@ -177,7 +177,7 @@ class JavaMap {
   }
 
   values() {
-    return new JavaArray(this.map.values());
+    return new JavaArray(Array.from(this.map.values()));
   }
 
   toJSON() {


### PR DESCRIPTION
JavaMap was incorrectly passing a MapIterator to the JavaArray class instead of an array.