### PR TITLE
Update velocityjs dependency to upstream package

### DIFF
--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -34,7 +34,7 @@
     "pkg-up": "^2.0.0",
     "serverless": "^1.30",
     "uuid": "^3.2.1",
-    "velocityjs": "lightsofapollo/velocity.js#allow-own-keyset"
+    "velocityjs": "^1.1.3"
   },
   "devDependencies": {
     "apollo-boost": "^0.1.7",


### PR DESCRIPTION
The `lightsofapollo:allow-own-keyset` changes were merged in `v1.1.1` https://github.com/shepherdwind/velocity.js/pull/106