### PR TITLE
Readme expansion and fix for Go code not compiling on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,56 @@ Home of various packages for testing, deploying and building applications on top
 
 ## Prerequisites
 
-Java version >= 8
+* Java version >= 8
+* Python 3
+* Golang 1.x
+* [aws-sam-cli](https://github.com/awslabs/aws-sam-cli)
+
+This repo tests that Go and Python serverless functions work. For the
+specs to run, you will need both Python 3 and Golang installed and to
+have built the Go files using the `.compileAll.sh` script.
 
 ## Developing
 
-This mono repo runs all tests through jest (including eslint!) to run the tests you first need to start `docker-compose`
+### Clone this repo and build everything:
 
-```sh
-yarn jest
+```bash
+git clone git@github.com:ConduitVC/aws-utils.git
+cd aws-utils
+go get -u github.com/aws/aws-lambda-go/lambda
+./compileAll.sh
 ```
+
+### Then make sure all the specs pass:
+
+This mono repo runs all tests through jest (including eslint!) to run
+the tests you first need to start `docker-compose` to make the localstack
+services available.
+
+```bash
+docker-compose run -d localstack
+docker-compose run wait
+yarn test
+```
+
+If you find the tests running slowly or with intermittent failures, try
+running this once to clear the Jest cache:
+
+```bash
+yarn test --clearCache
+```
+
+Also, check that you have enough RAM allocated to Docker. 4GB would be a
+good starting point.
+
+It may help to use `yarn test --runInBand` to stop the localstack stuff
+getting overwhelmed by the default parallel tests.
+
+To debug the tests, do this:
+
+```bash
+NODE_DEBUG=appsync-emulator:lambdaRunner TERM=dumb yarn test
+```
+
+Without `TERM=dumb`, any `console.log()` or log messages will be
+swallowed by Jest as it scrolls up to replace its own output.

--- a/compileAll.sh
+++ b/compileAll.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# This makes sure we compile for linux (used inside the SAM docker containers)
+# which won't happen if we are running this script from a Mac terminal.
+export GOOS=linux
+
 pushd packages/appsync-emulator-serverless/__test__/example/
 pushd gocomposedjson && go build gocomposedjson.go && popd
 pushd goemptyjson && go build goemptyjson.go && popd

--- a/packages/appsync-emulator-serverless/__test__/lambdaRunnerGo.test.js
+++ b/packages/appsync-emulator-serverless/__test__/lambdaRunnerGo.test.js
@@ -17,30 +17,43 @@ const run = ({ handlerMethod, payload = {} }) => {
   return e2p(child, 'message');
 };
 
+// These specs execute slowly on Mac, so need a larger timeout.
 describe('lambdaRunner', () => {
   describe('async go', () => {
-    it('return empty', async () => {
-      const response = await run({
-        handlerMethod: 'goemptyjson',
-      });
+    it(
+      'return empty',
+      async () => {
+        const response = await run({
+          handlerMethod: 'goemptyjson',
+        });
 
-      expect(response.type).toBe('success');
-      expect(response.output).toEqual({});
-    });
-    it('return object', async () => {
-      const response = await run({
-        handlerMethod: 'gocomposedjson',
-      });
+        expect(response.output).toEqual({});
+        expect(response.type).toBe('success');
+      },
+      40000,
+    );
+    it(
+      'return object',
+      async () => {
+        const response = await run({
+          handlerMethod: 'gocomposedjson',
+        });
 
-      expect(response.type).toBe('success');
-      expect(response.output).toEqual({ a: 1, b: 2, c: 3 });
-    });
-    it('throw error', async () => {
-      const response = await run({
-        handlerMethod: 'goerror',
-      });
+        expect(response.output).toEqual({ a: 1, b: 2, c: 3 });
+        expect(response.type).toBe('success');
+      },
+      40000,
+    );
+    it(
+      'throw error',
+      async () => {
+        const response = await run({
+          handlerMethod: 'goerror',
+        });
 
-      expect(response.type).toBe('error');
-    });
+        expect(response.type).toBe('error');
+      },
+      40000,
+    );
   });
 });

--- a/packages/appsync-emulator-serverless/__test__/tester.test.js
+++ b/packages/appsync-emulator-serverless/__test__/tester.test.js
@@ -8,7 +8,8 @@ const { AWSAppSyncClient } = require('aws-appsync');
 // eslint-disable-next-line
 global.fetch = require('node-fetch');
 
-describe('appasync-emulator-serverless/tester', () => {
+// These specs execute slowly on Mac, so need a larger timeout.
+describe('appsync-emulator-serverless/tester', () => {
   let serverSetup;
   beforeEach(async () => {
     jest.setTimeout(60 * 1000);
@@ -64,57 +65,61 @@ describe('appasync-emulator-serverless/tester', () => {
     });
   });
 
-  it('supports localstack', async () => {
-    serverSetup = await createTestServer({
-      serverless: `${__dirname}/example/serverless.yml`,
-      dynamodbConfig: {
-        endpoint: 'http://localhost:61023',
-        accessKeyId: 'fake',
-        secretAccessKey: 'fake',
-        region: 'fake',
-      },
-    });
-
-    const client = connectTestServer(serverSetup, AWSAppSyncClient);
-
-    const sub = await client.subscribe({
-      query: gql`
-        subscription sub {
-          subscribeToPutQuoteRequest {
-            id
-            commodity
-            amount
-          }
-        }
-      `,
-    });
-    const waiting = new Promise(accept => sub.subscribe(accept));
-    await client.mutate({
-      mutation: gql`
-        mutation test($input: QuoteRequestInput!) {
-          putQuoteRequest(input: $input) {
-            id
-            commodity
-            amount
-          }
-        }
-      `,
-      variables: {
-        input: {
-          commodity: 'foo',
-          amount: 100.5,
+  it(
+    'supports localstack',
+    async () => {
+      serverSetup = await createTestServer({
+        serverless: `${__dirname}/example/serverless.yml`,
+        dynamodbConfig: {
+          endpoint: 'http://localhost:61023',
+          accessKeyId: 'fake',
+          secretAccessKey: 'fake',
+          region: 'fake',
         },
-      },
-    });
+      });
 
-    const event = await waiting;
-    expect(event).toMatchObject({
-      data: {
-        subscribeToPutQuoteRequest: {
-          amount: 100.5,
-          commodity: 'foo',
+      const client = connectTestServer(serverSetup, AWSAppSyncClient);
+
+      const sub = await client.subscribe({
+        query: gql`
+          subscription sub {
+            subscribeToPutQuoteRequest {
+              id
+              commodity
+              amount
+            }
+          }
+        `,
+      });
+      const waiting = new Promise(accept => sub.subscribe(accept));
+      await client.mutate({
+        mutation: gql`
+          mutation test($input: QuoteRequestInput!) {
+            putQuoteRequest(input: $input) {
+              id
+              commodity
+              amount
+            }
+          }
+        `,
+        variables: {
+          input: {
+            commodity: 'foo',
+            amount: 100.5,
+          },
         },
-      },
-    });
-  });
+      });
+
+      const event = await waiting;
+      expect(event).toMatchObject({
+        data: {
+          subscribeToPutQuoteRequest: {
+            amount: 100.5,
+            commodity: 'foo',
+          },
+        },
+      });
+    },
+    40000,
+  );
 });


### PR DESCRIPTION
After finding that the README was not helping me to get the specs to pass locally, I found out what was wrong and have fixed and documented it here.

I am still finding that the entire test suite won't run locally in one go, but the failures are not consistent. I think that on my Mac (with 8GB RAM), docker finds it taxing. Running the specs individually is fine.