### PR TITLE
ExpressionAttributeNames should be null if empty

### DIFF
--- a/packages/appsync-emulator-serverless/dynamodbSource.js
+++ b/packages/appsync-emulator-serverless/dynamodbSource.js
@@ -145,10 +145,10 @@ const query = async (
     TableName: table,
     KeyConditionExpression: keyCondition.expression,
     FilterExpression: filter.expression,
-    ExpressionAttributeNames: {
+    ExpressionAttributeNames: nullIfEmpty({
       ...(filter.expressionNames || {}),
       ...(keyCondition.expressionNames || {}),
-    },
+    }),
     ExpressionAttributeValues: {
       ...(filter.expressionValues || {}),
       ...(keyCondition.expressionValues || {}),
@@ -202,9 +202,9 @@ const scan = async (
   if (filter) {
     Object.assign(params, {
       FilterExpression: filter.expression,
-      ExpressionAttributeNames: {
+      ExpressionAttributeNames: nullIfEmpty({
         ...(filter.expressionNames || undefined),
-      },
+      }),
       ExpressionAttributeValues: {
         ...(filter.expressionValues || undefined),
       },

--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduitvc/appsync-emulator-serverless",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "main": "schema.js",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
When using this kind of template:
````json
{
    "version" : "2017-02-28",
    "operation" : "Query",
    "query" : {
        "expression": "handle = :handle",
        "expressionValues" : {
            ":handle" : {
                "S" : "${context.arguments.handle}"
            }
        }
    }
}
````

I was getting an error 

````json
{
  "errors": [
    {
      "message": "ExpressionAttributeNames must not be empty",
      "locations": [
        {
          "line": 2,
          "column": 4
        }
      ],
      "path": [
        "getUserInfo"
      ]
    }
  ],
  "data": null
}

````

Doing this worked:
````json
{
    "version" : "2017-02-28",
    "operation" : "Query",
    "query" : {
        "expression": "#handle = :handle",
        "expressionNames": { "#handle": "handle" },
        "expressionValues" : {
            ":handle" : {
                "S" : "${context.arguments.handle}"
            }
        }
    }
}
````

However it should have worked the first time. (It does on a real deploy on AWS).
ExpressionAttributeNames should never be empty and should be undefined instead.
