### PR TITLE
Pass env vars to lambdas and keep colors in console

### DIFF
--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -10,7 +10,7 @@ const lambdaSource = async (
   {
     dynamodbEndpoint,
     dynamodbTables,
-    serverlessConfig: { functions = {}, custom = {} },
+    serverlessConfig: { functions = {}, custom = {}, provider = {} },
     serverlessDirectory,
   },
   fn,
@@ -54,8 +54,10 @@ const lambdaSource = async (
     child = fork(runner, [], {
       env: {
         ...process.env,
+        ...provider.environment,
         ...dynamodbTableAliases,
         DYNAMODB_ENDPOINT: dynamodbEndpoint,
+        FORCE_COLOR: true,
       },
       stdio: [0, 1, 2, 'ipc'],
     });
@@ -69,7 +71,9 @@ const lambdaSource = async (
     child = fork(Runner, [], {
       env: {
         ...dynamodbTableAliases,
+        ...provider.environment,
         DYNAMODB_ENDPOINT: dynamodbEndpoint,
+        FORCE_COLOR: true,
       },
       stdio: [0, 1, 2, 'ipc'],
     });


### PR DESCRIPTION
Lambda currently don't receive env vars from serverless.yml file.
This fixes it.
I also added the `FORCE_COLOR: true` env var to keep colors in the console logs.