### PR TITLE
Set aws provider

### DIFF
--- a/packages/appsync-emulator-serverless/loadServerlessConfig.js
+++ b/packages/appsync-emulator-serverless/loadServerlessConfig.js
@@ -4,6 +4,7 @@
  */
 
 const Serverless = require('serverless');
+const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider.js');
 const path = require('path');
 const fs = require('fs');
 
@@ -25,6 +26,8 @@ class ConfigServerless extends Serverless {
 
     // make sure the command exists before doing anything else
     this.pluginManager.validateCommand(this.processedInput.commands);
+
+    this.setProvider('aws', new AwsProvider(this, this.processedInput.options));
 
     // populate variables after --help, otherwise help may fail to print
     // (https://github.com/serverless/serverless/issues/2041)


### PR DESCRIPTION
When using [SSM Parameter Store](https://serverless.com/framework/docs/providers/aws/guide/variables#reference-variables-using-the-ssm-parameter-store), emulator failed because the aws provider was not set. 

