### PR TITLE
Make createServer accept a serverless instance

### DIFF
--- a/packages/appsync-emulator-serverless/server.js
+++ b/packages/appsync-emulator-serverless/server.js
@@ -51,12 +51,12 @@ const createSchema = async ({
     serverlessConfig = serverless.service;
     serverlessDirectory = serverless.config.servicePath;
   } else {
-    serverlessDirectory = typeof serverless === 'string'
-      ? path.dirname(serverless)
-      : findServerlessPath();
-    let { config: serverlessConfig } = await loadServerlessConfig(
-      serverlessDirectory,
-    );
+    serverlessDirectory =
+      typeof serverless === 'string'
+        ? path.dirname(serverless)
+        : findServerlessPath();
+    const config = await loadServerlessConfig(serverlessDirectory);
+    serverlessConfig = config.config;
   }
 
   // eslint-disable-next-line

--- a/packages/appsync-emulator-serverless/server.js
+++ b/packages/appsync-emulator-serverless/server.js
@@ -45,13 +45,19 @@ const createSchema = async ({
   pubsub,
   dynamodb,
 } = {}) => {
-  const serverlessDirectory =
-    typeof serverless === 'string'
+  let serverlessConfig = {};
+  let serverlessDirectory;
+  if (typeof serverless === 'object') {
+    serverlessConfig = serverless.service;
+    serverlessDirectory = serverless.config.servicePath;
+  } else {
+    serverlessDirectory = typeof serverless === 'string'
       ? path.dirname(serverless)
       : findServerlessPath();
-  const { config: serverlessConfig } = await loadServerlessConfig(
-    serverlessDirectory,
-  );
+    let { config: serverlessConfig } = await loadServerlessConfig(
+      serverlessDirectory,
+    );
+  }
 
   // eslint-disable-next-line
   schemaPath = schemaPath || path.join(serverlessDirectory, 'schema.graphql');


### PR DESCRIPTION
Makes createServer() accept a Serverless instance.
This is useful when used with this plugin: https://github.com/aheissenberger/serverless-appsync-offline since it already receives a fully instantiated instance of Serverless.

See #91  and https://github.com/aheissenberger/serverless-appsync-offline/pull/16