### PR TITLE
Add ...fnConfig.environment for env vars

### DIFF
--- a/packages/appsync-emulator-serverless/__test__/lambdaSource.test.js
+++ b/packages/appsync-emulator-serverless/__test__/lambdaSource.test.js
@@ -1,0 +1,101 @@
+const childProcess = require('child_process');
+const lambdaSource = require('../lambdaSource');
+const e2p = require('event-to-promise');
+
+jest.mock('child_process');
+jest.mock('event-to-promise');
+
+describe('lambdaSource', () => {
+  it('should call fork with correct arguments', async () => {
+    const spy = jest
+      .spyOn(childProcess, 'fork')
+      .mockImplementation(() => ({ send: jest.fn() }));
+    e2p.mockImplementation(async () =>
+      Promise.resolve({
+        type: 'success',
+        output: {},
+      }),
+    );
+    const config = {
+      dynamodbEndpoint: 'localhost',
+      dynamodbTables: {
+        USERS: 'users',
+        POSTS: 'posts',
+      },
+      serverlessDirectory: 'foo/bar',
+      serverlessConfig: {
+        provider: {
+          environment: {
+            DYNAMODB_USERNAME: 'dynamo',
+          },
+        },
+        functions: {
+          getUsers: {
+            handler: 'users.handler',
+            runtime: 'nodejs8.10',
+            environment: {
+              USER_ENV_1: 'foo',
+              USER_ENV_2: 'bar',
+            },
+          },
+          getPosts: {
+            handler: 'users.handler',
+            runtime: 'nodejs8.10',
+            environment: {
+              POST_ENV_1: 'bazz',
+              POST_ENV_2: 'buzz',
+            },
+          },
+        },
+      },
+    };
+    await lambdaSource(config, 'getUsers', {});
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(String),
+      [],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          DYNAMODB_USERNAME: 'dynamo',
+          DYNAMODB_TABLE_USERS: 'users',
+          DYNAMODB_TABLE_POSTS: 'posts',
+          USER_ENV_1: 'foo',
+          USER_ENV_2: 'bar',
+        }),
+      }),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(String),
+      [],
+      expect.objectContaining({
+        env: expect.not.objectContaining({
+          POST_ENV_1: 'bazz',
+          POST_ENV_2: 'buzz',
+        }),
+      }),
+    );
+    await lambdaSource(config, 'getPosts', {});
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(String),
+      [],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          DYNAMODB_USERNAME: 'dynamo',
+          DYNAMODB_TABLE_USERS: 'users',
+          DYNAMODB_TABLE_POSTS: 'posts',
+          POST_ENV_1: 'bazz',
+          POST_ENV_2: 'buzz',
+        }),
+      }),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(String),
+      [],
+      expect.objectContaining({
+        env: expect.not.objectContaining({
+          USER_ENV_1: 'foo',
+          USER_ENV_2: 'bar',
+        }),
+      }),
+    );
+  });
+});

--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -58,11 +58,10 @@ const lambdaSource = async (
     child = fork(runner, [], {
       env: {
         ...process.env,
-        ...provider.environment,
-        ...fnConfig.environment,
         ...dynamodbTableAliases,
         DYNAMODB_ENDPOINT: dynamodbEndpoint,
-        FORCE_COLOR: true,
+        ...provider.environment,
+        ...fnConfig.environment,
       },
       stdio: [0, 1, 2, 'ipc'],
     });
@@ -75,11 +74,11 @@ const lambdaSource = async (
   } else {
     child = fork(Runner, [], {
       env: {
+        ...process.env,
         ...dynamodbTableAliases,
+        DYNAMODB_ENDPOINT: dynamodbEndpoint,
         ...provider.environment,
         ...fnConfig.environment,
-        DYNAMODB_ENDPOINT: dynamodbEndpoint,
-        FORCE_COLOR: true,
       },
       stdio: [0, 1, 2, 'ipc'],
     });

--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -59,6 +59,7 @@ const lambdaSource = async (
       env: {
         ...process.env,
         ...provider.environment,
+        ...fnConfig.environment,
         ...dynamodbTableAliases,
         DYNAMODB_ENDPOINT: dynamodbEndpoint,
         FORCE_COLOR: true,
@@ -76,6 +77,7 @@ const lambdaSource = async (
       env: {
         ...dynamodbTableAliases,
         ...provider.environment,
+        ...fnConfig.environment,
         DYNAMODB_ENDPOINT: dynamodbEndpoint,
         FORCE_COLOR: true,
       },


### PR DESCRIPTION
I was also wondering if we should change the order of priority of env vars.

maybe

````js
        ...dynamodbTableAliases,
        DYNAMODB_ENDPOINT: dynamodbEndpoint,
        FORCE_COLOR: true,
        ...provider.environment,
        ...fnConfig.environment,
````

custom env vars should have priority ?