### PR TITLE
enable context.request in mapping templates

### DIFF
--- a/packages/appsync-emulator-serverless/schema.js
+++ b/packages/appsync-emulator-serverless/schema.js
@@ -47,12 +47,14 @@ class AppSyncError extends Error {
 const buildVTLContext = ({ root, vars, context, info }, result = null) => {
   const {
     jwt: { iss: issuer, sub },
+    request,
   } = context;
   const util = createUtils();
   const args = javaify(vars);
   const vtlContext = {
     arguments: args,
     args,
+    request,
     identity: javaify({
       sub,
       issuer,


### PR DESCRIPTION
Adds request to vtl context to be able to access it in resolver mapping templates as ```$context.request``` as specified by appsync  [here](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html)
```
Accessing the $context
The $context variable is a map which holds all of the contextual information for your resolver invocation. It has the following structure:

{
   "arguments" : { ... },
   "source" : { ... },
   "result" : { ... },
   "identity" : { ... },
   "request" : { ... }
}
```

I found this while tyring to access custom headers via ```$context.request.headers```