### PR TITLE
[102] AWSDate/Time inputs should parse into strings

### DIFF
--- a/packages/appsync-emulator-serverless/__test__/example/schema.graphql
+++ b/packages/appsync-emulator-serverless/__test__/example/schema.graphql
@@ -21,9 +21,9 @@ type Query {
   dateTest(dateTest: String): AWSDate
   timeTest(timeTest: String): AWSTime
   dateTimeTest(dateTimeTest: String): AWSDateTime
-  dateTestInput(dateTestInput: AWSDate): AWSDate
-  timeTestInput(timeTestInput: AWSTime): AWSTime
-  dateTimeTestInput(dateTimeTestInput: AWSDateTime): AWSDateTime
+  dateTestInput(dateTestInput: AWSDate): String
+  timeTestInput(timeTestInput: AWSTime): String
+  dateTimeTestInput(dateTimeTestInput: AWSDateTime): String
   emailTest(emailTest: String): AWSEmail
   phoneTest(phoneTest: String): AWSPhone
   urlTest(urlTest: String): AWSURL

--- a/packages/appsync-emulator-serverless/__test__/example/schema.graphql
+++ b/packages/appsync-emulator-serverless/__test__/example/schema.graphql
@@ -21,6 +21,9 @@ type Query {
   dateTest(dateTest: String): AWSDate
   timeTest(timeTest: String): AWSTime
   dateTimeTest(dateTimeTest: String): AWSDateTime
+  dateTestInput(dateTestInput: AWSDate): AWSDate
+  timeTestInput(timeTestInput: AWSTime): AWSTime
+  dateTimeTestInput(dateTimeTestInput: AWSDateTime): AWSDateTime
   emailTest(emailTest: String): AWSEmail
   phoneTest(phoneTest: String): AWSPhone
   urlTest(urlTest: String): AWSURL

--- a/packages/appsync-emulator-serverless/__test__/example/serverless.yml
+++ b/packages/appsync-emulator-serverless/__test__/example/serverless.yml
@@ -154,6 +154,21 @@ custom:
         response: result-response.txt
       - dataSource: TestLambda
         type: Query
+        field: dateTestInput
+        request: lambda-request.vtl
+        response: result-response.txt
+      - dataSource: TestLambda
+        type: Query
+        field: timeTestInput
+        request: lambda-request.vtl
+        response: result-response.txt
+      - dataSource: TestLambda
+        type: Query
+        field: dateTimeTestInput
+        request: lambda-request.vtl
+        response: result-response.txt
+      - dataSource: TestLambda
+        type: Query
         field: emailTest
         request: lambda-request.vtl
         response: result-response.txt

--- a/packages/appsync-emulator-serverless/__test__/schemaTest.test.js
+++ b/packages/appsync-emulator-serverless/__test__/schemaTest.test.js
@@ -578,6 +578,51 @@ describe('creates executable schema', () => {
     expectScalarResult(result, field, val);
   });
 
+  it('AWSDate scalar input', async () => {
+    const field = 'dateTestInput';
+    const val = new Date('05 October 2011').toISOString().split('T')[0];
+
+    const source = getScalarSource(field, val);
+
+    const result = await graphql({
+      schema,
+      contextValue,
+      source,
+    });
+
+    expectScalarResult(result, field, val);
+  });
+
+  it('AWSTime scalar input', async () => {
+    const field = 'timeTestInput';
+    const val = new Date('05 October 2011').toISOString().split('T')[1];
+
+    const source = getScalarSource(field, val);
+
+    const result = await graphql({
+      schema,
+      contextValue,
+      source,
+    });
+
+    expectScalarResult(result, field, val);
+  });
+
+  it('AWSDateTime scalar input', async () => {
+    const field = 'dateTimeTestInput';
+    const val = new Date('05 October 2011').toISOString();
+
+    const source = getScalarSource(field, val);
+
+    const result = await graphql({
+      schema,
+      contextValue,
+      source,
+    });
+
+    expectScalarResult(result, field, val);
+  });
+
   it('AWSEmail scalar', async () => {
     const field = 'emailTest';
     const val = 'foobar@example.com';

--- a/packages/appsync-emulator-serverless/schemaWrapper.js
+++ b/packages/appsync-emulator-serverless/schemaWrapper.js
@@ -1,3 +1,4 @@
+const { GraphQLScalarType } = require('graphql');
 const GraphQLJSON = require('graphql-type-json');
 
 const {
@@ -10,11 +11,53 @@ const GraphQLPhoneType = require('graphql-phone-type');
 
 const { EmailAddress, URL } = require('@okgrow/graphql-scalars');
 
+const AWSDate = new GraphQLScalarType({
+  name: 'AWSDate',
+  description: GraphQLDate.description,
+  serialize(value) {
+    return GraphQLDate.serialize(value);
+  },
+  parseValue(value) {
+    return GraphQLDate.parseValue(value) ? value : undefined;
+  },
+  parseLiteral(value) {
+    return GraphQLDate.parseLiteral(value) ? value.value : undefined;
+  },
+});
+
+const AWSTime = new GraphQLScalarType({
+  name: 'AWSTime',
+  description: GraphQLTime.description,
+  serialize(value) {
+    return GraphQLTime.serialize(value);
+  },
+  parseValue(value) {
+    return GraphQLTime.parseValue(value) ? value : undefined;
+  },
+  parseLiteral(value) {
+    return GraphQLTime.parseLiteral(value) ? value.value : undefined;
+  },
+});
+
+const AWSDateTime = new GraphQLScalarType({
+  name: 'AWSDateTime',
+  description: GraphQLDateTime.description,
+  serialize(value) {
+    return GraphQLDateTime.serialize(value);
+  },
+  parseValue(value) {
+    return GraphQLDateTime.parseValue(value) ? value : undefined;
+  },
+  parseLiteral(value) {
+    return GraphQLDateTime.parseLiteral(value) ? value.value : undefined;
+  },
+});
+
 const scalars = {
   AWSJSON: GraphQLJSON,
-  AWSDate: GraphQLDate,
-  AWSTime: GraphQLTime,
-  AWSDateTime: GraphQLDateTime,
+  AWSDate,
+  AWSTime,
+  AWSDateTime,
   AWSPhone: GraphQLPhoneType,
   AWSEmail: EmailAddress,
   AWSURL: URL,


### PR DESCRIPTION
fixes #102

- [x] added tests
- [x] fix `schemaWrapper.js`

CI failure of the latest commit on Node 10 looks unrelated. 