### PR TITLE
Fix $util.time.nowEpochSeconds()

### DIFF
--- a/packages/appsync-emulator-serverless/util.js
+++ b/packages/appsync-emulator-serverless/util.js
@@ -124,7 +124,7 @@ const create = (errors = [], now = new Date()) => ({
       return now.toISOString();
     },
     nowEpochSeconds() {
-      return parseInt(now.valueOf() / 1000);
+      return parseInt(now.valueOf() / 1000, 10);
     },
     nowEpochMilliSeconds() {
       return now.valueOf();

--- a/packages/appsync-emulator-serverless/util.js
+++ b/packages/appsync-emulator-serverless/util.js
@@ -124,7 +124,7 @@ const create = (errors = [], now = new Date()) => ({
       return now.toISOString();
     },
     nowEpochSeconds() {
-      return now.valueOf() / 1000;
+      return parseInt(now.valueOf() / 1000);
     },
     nowEpochMilliSeconds() {
       return now.valueOf();


### PR DESCRIPTION
$util.time.nowEpochSeconds() must return a long value, not a float.