### PR TITLE
Fix race condition by using safe mkdir

### DIFF
--- a/packages/dynamodb-emulator/client.js
+++ b/packages/dynamodb-emulator/client.js
@@ -8,6 +8,7 @@ const { flockSync } = require('fs-ext');
 const { spawn } = require('child_process');
 const log = require('logdown')('dynamodb-emulator:client');
 const { getClient } = require('./index');
+const mkdirSafe = require('./mkdirSafe');
 const { homedir } = require('os');
 
 const homeDir = homedir();
@@ -84,9 +85,7 @@ async function requestEmulator(unixSocketFile, options) {
 }
 
 async function startDeamon(hash, unixSocketFile, options) {
-  if (!fs.existsSync(pidPath)) {
-    fs.mkdirSync(pidPath);
-  }
+  mkdirSafe(pidPath);
   // file does not exist so we will need to create one.
   const pidFile = path.join(pidPath, `${hash}.pid`);
   const fd = fs.openSync(pidFile, 'w');

--- a/packages/dynamodb-emulator/index.js
+++ b/packages/dynamodb-emulator/index.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const waitPort = require('wait-port');
 const portPid = require('port-pid');
 const log = require('logdown')('dynamodb-emulator');
+const mkdirSafe = require('./mkdirSafe');
 
 // random port I chose in the ephemeral range.
 const basePort = 62224;
@@ -121,7 +122,7 @@ async function launch(givenOptions = {}, retry = 0, startTime = Date.now()) {
       }
     } else {
       log.info('Creating directory', { dbPath: opts.dbPath });
-      fs.mkdirSync(opts.dbPath);
+      mkdirSafe(opts.dbPath);
     }
   }
 

--- a/packages/dynamodb-emulator/mkdirSafe.js
+++ b/packages/dynamodb-emulator/mkdirSafe.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+
+// A mkdirSync which will not throw when directory exists already...
+module.exports = path => {
+  try {
+    fs.mkdirSync(path);
+  } catch (err) {
+    if (err.code === 'EEXIST') {
+      return;
+    }
+    throw err;
+  }
+};


### PR DESCRIPTION
There is a race condition where two launching emulators can cause an exception. This is due to using `fs.mkdirSync` which can throw if directory exists. While we check for the directories another process/thread could easily create them between the check and mkdirSync.