### PR TITLE
Add JavaString to the vtl value mapper

### DIFF
--- a/packages/appsync-emulator-serverless/__test__/example/mapping-templates/update-request.txt
+++ b/packages/appsync-emulator-serverless/__test__/example/mapping-templates/update-request.txt
@@ -2,7 +2,7 @@
 #set($expressionNames = {"#modifyDate": "modifyDate"})
 #set($expression = "SET #modifyDate = :modifyDate, ")
 #foreach( $key in $ctx.args.input.keySet() )
-  $util.quiet($expressionValues.put(":$key", $util.dynamodb.toDynamoDB($ctx.args.input.get($key))))
+  $util.quiet($expressionValues.put(":$key", $util.dynamodb.toDynamoDB($ctx.args.input.get("$key"))))
   $util.quiet($expressionNames.put("#$key", $key))
   #if ($foreach.hasNext)
     #set($expression = "$expression #$key = :$key, ")

--- a/packages/appsync-emulator-serverless/vtl.js
+++ b/packages/appsync-emulator-serverless/vtl.js
@@ -10,7 +10,11 @@ const javaify = value => {
     // eslint-disable-next-line
     return new JavaArray(value.map(x => javaify(x)));
   }
-  if (value != null && typeof value === 'object') {
+  if (
+    value != null &&
+    typeof value === 'object' &&
+    value.constructor === Object
+  ) {
     // eslint-disable-next-line
     return createMapProxy(
       // eslint-disable-next-line
@@ -26,7 +30,13 @@ const javaify = value => {
     );
   }
 
-  // for now we don't handle string/number.
+  // eslint-disable-next-line
+  if (typeof value === 'string' && !(value instanceof JavaString)) {
+    // eslint-disable-next-line
+    return new JavaString(value);
+  }
+
+  // for now we don't handle number.
   return value;
 };
 
@@ -36,6 +46,25 @@ const toJSON = value => {
   }
   return value;
 };
+
+class JavaString {
+  constructor(str) {
+    this.strVal = str;
+  }
+
+  replaceAll(...args) {
+    const rep = this.strVal.replace(new RegExp(args[0], 'g'), args[1]);
+    return new JavaString(rep);
+  }
+
+  toJSON() {
+    return this.toString();
+  }
+
+  toString() {
+    return this.strVal;
+  }
+}
 
 class JavaArray extends Array {
   // required so array starts with zero elements
@@ -111,7 +140,9 @@ class JavaMap {
   constructor(obj) {
     this.map = new Map();
     this.toJSON = this.toJSON.bind(this);
-    Object.entries(obj).forEach(([key, value]) => this.map.set(key, value));
+    Object.entries(obj).forEach(([key, value]) => {
+      this.map.set(key, value);
+    });
   }
 
   clear() {
@@ -145,7 +176,7 @@ class JavaMap {
   }
 
   get(key) {
-    if (this.map.has(key)) {
+    if (this.map.has(key.toString())) {
       return this.map.get(key);
     }
     return null;

--- a/packages/appsync-emulator-serverless/vtl.js
+++ b/packages/appsync-emulator-serverless/vtl.js
@@ -52,8 +52,8 @@ class JavaString {
     this.strVal = str;
   }
 
-  replaceAll(...args) {
-    const rep = this.strVal.replace(new RegExp(args[0], 'g'), args[1]);
+  replaceAll(find, replace) {
+    const rep = this.strVal.replace(new RegExp(find, 'g'), replace);
     return new JavaString(rep);
   }
 


### PR DESCRIPTION
My second attempt at adding JavaString to the value mapper.

Please provide feedback. 

`schemaTest.test.js` was throwing an error without the additional quotes in `update-request.txt`. I'm not sure if the bug is in new valueMapper or in the mapping template.

I also added some additional tests around the value mapper.