### PR TITLE
[111] AppSync Emulator - fix `defaultIfNull`

### DIFF
--- a/packages/appsync-emulator-serverless/util.js
+++ b/packages/appsync-emulator-serverless/util.js
@@ -74,7 +74,7 @@ const create = (errors = [], now = new Date()) => ({
     return !!value;
   },
   defaultIfNull(value, defaultValue = '') {
-    if (value !== null) return value;
+    if (value !== null && value !== undefined) return value;
     return defaultValue;
   },
   defaultIfNullOrEmpty(value, defaultValue) {


### PR DESCRIPTION
fixes the issue with `defaultIfNull` from #111