### PR TITLE
[134] AppSync Emulator - Implement `conditionalCheckFailedHandler`

### DIFF
--- a/packages/appsync-emulator-serverless/dynamodbSource.js
+++ b/packages/appsync-emulator-serverless/dynamodbSource.js
@@ -95,11 +95,11 @@ const putItem = async (
       if (
         isEqual(
           Object.entries(oldValues).reduce((newObject, [k, v]) => {
-            if (ignoreKeys.indexOf(k) === -1) return { ...newObject, k: v };
+            if (ignoreKeys.indexOf(k) === -1) return { ...newObject, [k]: v };
             return newObject;
           }, {}),
           Object.entries(shouldBeValues).reduce((newObject, [k, v]) => {
-            if (ignoreKeys.indexOf(k) === -1) return { ...newObject, k: v };
+            if (ignoreKeys.indexOf(k) === -1) return { ...newObject, [k]: v };
             return newObject;
           }, {}),
         )

--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -31,6 +31,7 @@
     "jwt-decode": "^2.2.0",
     "libphonenumber-js": "^1.7.16",
     "logdown": "^3.2.3",
+    "lodash.isequal": "^4.5.0",
     "node-fetch": "^2.2.0",
     "paho-mqtt": "^1.0.4",
     "pkg-up": "^2.0.0",


### PR DESCRIPTION
This PR implements strategy  "Reject" for PutItem.

Currently using  `lodash.omit` and `lodash.isEqual`. Not sure what the policy for including 3rd party libs is. Any preferred method for deep equality comparison?

Strategy "Custom" would need considerably more work as it cannot be handled in `dynamodbSource.js` alone. The current implementation attaches the old values to the `ConditionalCheckFailedException` before re-throwing when strategy is "Custom".

Partial implementation of #134