### PR TITLE
Allow execution of child process on lambda fork process

### DIFF
--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -72,7 +72,7 @@ const lambdaSource = async (
       payload,
     });
   } else {
-    child = fork(Runner, [], {
+    const childOptions = {
       env: {
         ...process.env,
         ...dynamodbTableAliases,
@@ -80,8 +80,10 @@ const lambdaSource = async (
         ...provider.environment,
         ...fnConfig.environment,
       },
-      stdio: [0, 1, 2, 'ipc'],
-    });
+      stdio: [0, 1, 2, 'ipc']
+    };
+    if (process.env.SLS_DEBUG) childOptions.execArgv = ['--inspect-brk'];
+    child = fork(Runner, [], childOptions);
 
     child.send({
       module: fullPath,

--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -80,7 +80,7 @@ const lambdaSource = async (
         ...provider.environment,
         ...fnConfig.environment,
       },
-      stdio: [0, 1, 2, 'ipc']
+      stdio: [0, 1, 2, 'ipc'],
     };
     if (process.env.SLS_DEBUG) childOptions.execArgv = ['--inspect-brk'];
     child = fork(Runner, [], childOptions);


### PR DESCRIPTION
This allow execution of child process on lambda fork process with the '--inspect-brk' for debuggin propurses, can also be used NODE_DEBUG="appsync-*" as check to know if debug env is on, in this code put SLS_DEBUG but feel free to use which you think is better. Pseudo ides like VSCode can now (with auto attach child process set to true) attach to lambda worker and debug line by line.
I choosed inspect-brk over inspect because node will resolve which port is empty for debug.