### PR TITLE
Allow for multiple AppSync Api's in config

### DIFF
--- a/packages/appsync-emulator-serverless/README.md
+++ b/packages/appsync-emulator-serverless/README.md
@@ -82,6 +82,20 @@ custom:
 
 Where `$PREFIX_LOCATION` is your specified webpack build path i.e. `.webpack`
 
+### Serverless configuration notes
+
+AppSync emulator does support Serverless configurations with multiple endpoints. Like the sample below.
+
+```
+custom:
+  appsync:
+    - name: 'api 1'
+       ...
+    - name: 'api 2'
+```
+**However:** It does not start multiple endpoints, it will only use the first endpoint.
+ 
+
 ## Testing
 
 ### Jest

--- a/packages/appsync-emulator-serverless/__test__/util.test.js
+++ b/packages/appsync-emulator-serverless/__test__/util.test.js
@@ -3,6 +3,7 @@ const {
   Unauthorized,
   TemplateSentError,
   CustomTemplateException,
+  getAppSyncConfig,
 } = require('../util');
 const { javaify } = require('../vtl');
 
@@ -218,6 +219,35 @@ describe('util', () => {
         beep: {
           L: [{ S: 'boop' }],
         },
+      });
+    });
+  });
+
+  describe('getAppSyncConfig', () => {
+    it('single api', () => {
+      expect(
+        getAppSyncConfig({ custom: { appSync: { name: 'test' } } }),
+      ).toEqual({
+        name: 'test',
+      });
+    });
+    it("multiple api's", () => {
+      expect(
+        getAppSyncConfig({
+          custom: { appSync: [{ name: 'first' }, { name: 'second' }] },
+        }),
+      ).toEqual({
+        name: 'first',
+      });
+    });
+
+    it("multiple api's with no name", () => {
+      expect(
+        getAppSyncConfig({
+          custom: { appSync: [{ randomConfig: 1 }, { name: 'second' }] },
+        }),
+      ).toEqual({
+        randomConfig: 1,
       });
     });
   });

--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduitvc/appsync-emulator-serverless",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "main": "schema.js",
   "license": "Apache-2.0",
   "bin": {

--- a/packages/appsync-emulator-serverless/schema.js
+++ b/packages/appsync-emulator-serverless/schema.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const path = require('path');
 const json5 = require('json5');
 const { GraphQLError } = require('graphql');
-const { create: createUtils } = require('./util');
+const { create: createUtils, getAppSyncConfig } = require('./util');
 const { javaify, vtl } = require('./vtl');
 const dynamodbSource = require('./dynamodbSource');
 const lambdaSource = require('./lambdaSource');
@@ -403,7 +403,7 @@ const createSchema = async ({
   assert(pubsub, 'must pass pubsub');
 
   const { subscriptions, DirectiveVisitor } = createSubscriptionsVisitor();
-  const { custom: { appSync: appSyncConfig } = {} } = serverlessConfig;
+  const appSyncConfig = getAppSyncConfig(serverlessConfig);
 
   // XXX: Below is a nice and easy hack.
   // walk the AST without saving the schema ... this is to capture subscription directives.

--- a/packages/appsync-emulator-serverless/server.js
+++ b/packages/appsync-emulator-serverless/server.js
@@ -8,6 +8,7 @@ const createServerCore = require('./serverCore');
 const log = require('logdown')('appsync-emulator:server');
 const { wrapSchema } = require('./schemaWrapper');
 const { cloudFormationProcessor } = require('./cloudFormationProcessor');
+const { getAppSyncConfig } = require('./util');
 
 const ensureDynamodbTables = async (
   dynamodb,
@@ -72,7 +73,8 @@ const createSchema = async ({
   }
 
   const graphqlSchema = wrapSchema(fs.readFileSync(schemaPath, 'utf8'));
-  const { custom: { appSync: appSyncConfig } = {} } = cfConfig;
+  const appSyncConfig = getAppSyncConfig(cfConfig);
+
   const dynamodbTables = await ensureDynamodbTables(
     dynamodb,
     cfConfig,

--- a/packages/appsync-emulator-serverless/util.js
+++ b/packages/appsync-emulator-serverless/util.js
@@ -1,4 +1,5 @@
 const { toJSON } = require('./vtl');
+const log = require('logdown')('appsync-emulator:util');
 
 class Unauthorized extends Error {}
 class TemplateSentError extends Error {
@@ -277,9 +278,27 @@ const create = (errors = [], now = new Date()) => ({
   },
 });
 
+const getAppSyncConfig = cfConfig => {
+  const { custom: { appSync: appSyncConfig } = {} } = cfConfig;
+
+  if (!Array.isArray(appSyncConfig)) {
+    return appSyncConfig;
+  }
+
+  if (appSyncConfig.length > 1) {
+    const apiName = appSyncConfig[0].name || 'api';
+    log.warn(
+      `Multiple API's are not supported, using first instance: ${apiName}`,
+    );
+  }
+
+  return appSyncConfig[0];
+};
+
 module.exports = {
   create,
   TemplateSentError,
   Unauthorized,
   ValidateError,
+  getAppSyncConfig,
 };


### PR DESCRIPTION
As per this issue: https://github.com/ConduitVC/aws-utils/issues/140

This PR allows for multiple API's in the YML config as this is supported by `serverless-appsync-plugin`

```
custom: 
  appsync: 
    - name: 'api 1'
       ...
    - name: 'api 2'
```

But not to make things too complex, only use the first api in the emulator for now... I'm not going to implement that support it's over and beyond what's needed.

I'm throwing a warning to stipulate that it's not supported and which API will be used in the emulator.
