### PR TITLE
Report lambda errors in logs

### DIFF
--- a/packages/appsync-emulator-serverless/lambdaRunner.js
+++ b/packages/appsync-emulator-serverless/lambdaRunner.js
@@ -32,6 +32,7 @@ process.once(
         sendOutput(await lambdaResult);
       }
     } catch (err) {
+      log.error(err);
       sendErr(err);
     }
   },


### PR DESCRIPTION
I ran into an issue recently where my Lambda was failing silently, with no errors coming through the logger. But the error is being reported GraphQL call _(Kinda it doesn't show the contents of the error, just that there's an error 😝)_

Notes: I had the logging set to `NODE_DEBUG=appsync-emulator:*` 

This one line change now reports the error in the logs.