### PR TITLE
Extend flatten function usage to serverless object

### DIFF
--- a/packages/appsync-emulator-serverless/loadServerlessConfig.js
+++ b/packages/appsync-emulator-serverless/loadServerlessConfig.js
@@ -6,6 +6,7 @@
 const Serverless = require('serverless');
 const path = require('path');
 const fs = require('fs');
+const util = require('./util');
 
 // const testCWD = '/Users/sahajalal/workspace/conduit/file-service/backend';
 
@@ -75,14 +76,6 @@ const normalizeResources = config => {
   };
 };
 
-const flatten = arr =>
-  arr.reduce((acc, curr) => {
-    if (Array.isArray(curr)) {
-      return [...acc, ...flatten(curr)];
-    }
-    return [...acc, curr];
-  }, []);
-
 const loadServerlessConfig = async (cwd = process.cwd()) => {
   const stat = fs.statSync(cwd);
   if (!stat.isDirectory()) {
@@ -99,8 +92,8 @@ const loadServerlessConfig = async (cwd = process.cwd()) => {
 
   const { custom = {} } = config;
   const { appSync = {} } = custom;
-  const { mappingTemplates = [] } = appSync;
-  const { dataSources = [] } = appSync;
+
+  util.flatteningMappingTemplatesAndDataSources(appSync);
 
   const output = {
     config: {
@@ -109,8 +102,6 @@ const loadServerlessConfig = async (cwd = process.cwd()) => {
         ...custom,
         appSync: {
           ...appSync,
-          mappingTemplates: flatten(mappingTemplates),
-          dataSources: flatten(dataSources),
         },
       },
       resources: normalizeResources(config),

--- a/packages/appsync-emulator-serverless/server.js
+++ b/packages/appsync-emulator-serverless/server.js
@@ -8,7 +8,10 @@ const createServerCore = require('./serverCore');
 const log = require('logdown')('appsync-emulator:server');
 const { wrapSchema } = require('./schemaWrapper');
 const { cloudFormationProcessor } = require('./cloudFormationProcessor');
-const { getAppSyncConfig } = require('./util');
+const {
+  getAppSyncConfig,
+  flatteningMappingTemplatesAndDataSources,
+} = require('./util');
 
 const ensureDynamodbTables = async (
   dynamodb,
@@ -51,6 +54,9 @@ const createSchema = async ({
   let serverlessDirectory;
   if (typeof serverless === 'object') {
     serverlessConfig = serverless.service;
+    const appSyncConfig = getAppSyncConfig(serverlessConfig);
+    flatteningMappingTemplatesAndDataSources(appSyncConfig);
+    serverlessConfig.appSyncConfig = appSyncConfig;
     serverlessDirectory = serverless.config.servicePath;
   } else {
     serverlessDirectory =

--- a/packages/appsync-emulator-serverless/util.js
+++ b/packages/appsync-emulator-serverless/util.js
@@ -295,10 +295,32 @@ const getAppSyncConfig = cfConfig => {
   return appSyncConfig[0];
 };
 
+const flatten = arr =>
+  arr.reduce((acc, curr) => {
+    if (Array.isArray(curr)) {
+      return [...acc, ...flatten(curr)];
+    }
+    return [...acc, curr];
+  }, []);
+
+const flatteningMappingTemplatesAndDataSources = appSync => {
+  // eslint-disable-next-line
+  appSync.mappingTemplates =
+    typeof appSync.mappingTemplates !== 'undefined'
+      ? flatten(appSync.mappingTemplates)
+      : [];
+  // eslint-disable-next-line
+  appSync.dataSources =
+    typeof appSync.dataSources !== 'undefined'
+      ? flatten(appSync.dataSources)
+      : [];
+};
+
 module.exports = {
   create,
   TemplateSentError,
   Unauthorized,
   ValidateError,
   getAppSyncConfig,
+  flatteningMappingTemplatesAndDataSources,
 };


### PR DESCRIPTION
I moved `flatten` function to `util.js` and create method `flatteningMappingTemplatesAndDataSources`. In this way i can flatten `mappingTemplates` and `dataSources` when we load configuration from file and when serverless configuration object has been passed from outside (e.g. using serverless-appsync-offline plugin). 