### PR TITLE
feat/support "application/graphql" content-type

### DIFF
--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduitvc/appsync-emulator-serverless",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "main": "schema.js",
   "license": "Apache-2.0",
   "bin": {

--- a/packages/appsync-emulator-serverless/serverCore.js
+++ b/packages/appsync-emulator-serverless/serverCore.js
@@ -379,7 +379,7 @@ const createServer = async ({
 
   // graphql server.
   const app = express();
-  app.use(express.json());
+  app.use(express.json({ type: ['application/graphql', 'application/json'] }));
   app.use(require('cors')());
   const handler = createGQLHandler({ schema, subServer });
 


### PR DESCRIPTION
Add support for `application/graphql` content-type

To be honest I'm not sure if more is required, after this change my requests from the client started working as expected.

✅ ran linter
✅ tested locally
✅ also checked that it won't break body-parser https://github.com/expressjs/body-parser/blob/master/lib/types/json.js#L59