### PR TITLE
--dynamodb-port CLI arg works again

### DIFF
--- a/packages/appsync-emulator-serverless/dynamodbUtil.js
+++ b/packages/appsync-emulator-serverless/dynamodbUtil.js
@@ -5,6 +5,7 @@ const { DynamoDB } = require('aws-sdk');
 async function deriveDynamoDBClient(
   { DynamoDB: config },
   emulatorPath = process.cwd(),
+  port,
 ) {
   if (config === false) {
     // if false, we assume dynamo is not needed
@@ -19,7 +20,6 @@ async function deriveDynamoDBClient(
   // start the dynamodb emulator
   const dynamoEmulator = require('@conduitvc/dynamodb-emulator');
   const dbPath = path.join(path.dirname(emulatorPath), '.dynamodb');
-  const { port } = config;
   const emulator = await dynamoEmulator.launch({
     dbPath,
     port,


### PR DESCRIPTION
- version 0.14 of the emulator broke the use of a fixed dynamoDB port specified via CLI as `--dynamodb-port`. I have fixed this by restoring a missing function parameter for the port and using that when there is no custom config file.