### PR TITLE
Prevent SLS_DEBUG from breaking Lambda Invoke

### DIFF
--- a/packages/appsync-emulator-serverless/lambdaSource.js
+++ b/packages/appsync-emulator-serverless/lambdaSource.js
@@ -82,7 +82,7 @@ const lambdaSource = async (
       },
       stdio: [0, 1, 2, 'ipc'],
     };
-    if (process.env.SLS_DEBUG) childOptions.execArgv = ['--inspect-brk'];
+    if (process.env.SLS_DEBUG) childOptions.execArgv = ['--inspect'];
     child = fork(Runner, [], childOptions);
 
     child.send({

--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduitvc/appsync-emulator-serverless",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "main": "schema.js",
   "license": "Apache-2.0",
   "bin": {


### PR DESCRIPTION
Before this commit, child_process breaks execution flow when invoked by a lambda function with SLS_DEBUG set in environment. This is as a result of childOptions execArgv --inspect-brk when using nodejs runtime.

Changing execArgs to --inspect will help new comers to not encounter such unexplained functionality :).