### PR TITLE
Update schema.js to accomodate default vtl names

### DIFF
--- a/packages/appsync-emulator-serverless/schema.js
+++ b/packages/appsync-emulator-serverless/schema.js
@@ -291,8 +291,8 @@ const generateResolvers = (cwd, config, configs) => {
       }
       const source = dataSourceByName[dataSource];
       const pathing = {
-        requestPath: path.join(mappingTemplates, request),
-        responsePath: path.join(mappingTemplates, response),
+        requestPath: path.join(mappingTemplates, request || `${type}.${field}.request.vtl`),
+        responsePath: path.join(mappingTemplates, response || `${type}.${field}.response.vtl`),
       };
       const resolver =
         type === 'Subscription'


### PR DESCRIPTION
appSync-serverless now allows VTL files to default to a {type}.{field}.request|response.vtl naming format.

https://github.com/sid88in/serverless-appsync-plugin/blob/e972141e23d35286b5613e75c4bed9da0413cdec/index.js#L762

This commit updates schema.js to accomodate that default naming format.