### PR TITLE
Prevents auto escape from velocity.render

### DIFF
--- a/packages/appsync-emulator-serverless/package.json
+++ b/packages/appsync-emulator-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conduitvc/appsync-emulator-serverless",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "main": "schema.js",
   "license": "Apache-2.0",
   "bin": {

--- a/packages/appsync-emulator-serverless/vtl.js
+++ b/packages/appsync-emulator-serverless/vtl.js
@@ -257,7 +257,7 @@ const vtl = (str, context, macros = {}) => {
   log.info('render\n', str);
   const output = velocity.render(str, context, macros, {
     valueMapper: javaify,
-    escape: false
+    escape: false,
   });
   log.info('render output\n', output);
   return output;

--- a/packages/appsync-emulator-serverless/vtl.js
+++ b/packages/appsync-emulator-serverless/vtl.js
@@ -257,6 +257,7 @@ const vtl = (str, context, macros = {}) => {
   log.info('render\n', str);
   const output = velocity.render(str, context, macros, {
     valueMapper: javaify,
+    escape: false
   });
   log.info('render output\n', output);
   return output;


### PR DESCRIPTION
This causes JSON objects to be escaped, which down the line fail on JSON parsing